### PR TITLE
Make compile-examples support boards that require --additional-urls flag

### DIFF
--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -11,6 +11,10 @@ The version of `arduino-cli` to use. Default `"latest"`.
 ### `fqbn`
 
 **Required** The fully qualified board name to use when compiling. Default `"arduino:avr:uno"`.
+For 3rd party boards, also specify the Boards Manager URL:
+```yaml
+  fqbn: '"sandeepmistry:nRF5:Generic_nRF52832" "https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json"'
+```
 
 ### `libraries`
 

--- a/libraries/compile-examples/action.yml
+++ b/libraries/compile-examples/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'Version of arduino-cli to use when builing'
     default: 'latest'
   fqbn:
-    description: 'Full qualified board name'
+    description: 'Full qualified board name, with Boards Manager URL if needed'
     required: true
     default: 'arduino:avr:uno'
   libraries:

--- a/libraries/compile-examples/entrypoint.sh
+++ b/libraries/compile-examples/entrypoint.sh
@@ -1,15 +1,20 @@
 #!/bin/bash -x
 
 CLI_VERSION=$1
-FQBN=$2
+FQBN_ARG=$2
 LIBRARIES=$3
 
 # Determine cli archive
 CLI_ARCHIVE=arduino-cli_${CLI_VERSION}_Linux_64bit.tar.gz
 
+declare -a -r FQBN_ARRAY="(${FQBN_ARG})"
+FQBN="${FQBN_ARRAY[0]}"
 # Extract the core name from the FQBN
 # for example arduino:avr:uno => arduino:avr
 CORE=`echo "$FQBN" | cut -d':' -f1,2`
+
+# Additional Boards Manager URL
+ADDITIONAL_URL="${FQBN_ARRAY[1]}"
 
 # Download the arduino-cli
 wget -P $HOME https://downloads.arduino.cc/arduino-cli/$CLI_ARCHIVE
@@ -22,8 +27,13 @@ tar xf $HOME/$CLI_ARCHIVE -C $HOME/bin
 export PATH=$PATH:$HOME/bin
 
 # Update the code index and install the required CORE
-arduino-cli core update-index
-arduino-cli core install $CORE
+if [ -z "$ADDITIONAL_URL" ]; then
+  arduino-cli core update-index
+  arduino-cli core install $CORE
+else
+  arduino-cli core update-index --additional-urls $ADDITIONAL_URL
+  arduino-cli core install $CORE --additional-urls $ADDITIONAL_URL
+fi
 
 # Install libraries if needed
 if [ -z "$LIBRARIES" ]


### PR DESCRIPTION
In order to compile for 3rd party boards, the Boards Manager URL must be passed to the action.

Demonstration workflow run using the updated compile-examples action:
https://github.com/per1234/Arduino_ConnectionHandler/runs/396674491