### PR TITLE
Make compile-examples fail if any compilation failed

### DIFF
--- a/libraries/compile-examples/entrypoint.sh
+++ b/libraries/compile-examples/entrypoint.sh
@@ -39,7 +39,15 @@ ln -s $PWD $HOME/Arduino/libraries/.
 
 # Find all the examples and loop build each
 EXAMPLES=`find examples/ -name '*.ino' | xargs dirname | uniq`
+# Set default exit status
+SCRIPT_EXIT_STATUS=0
 for EXAMPLE in $EXAMPLES; do
   echo Building example $EXAMPLE
   arduino-cli compile --verbose --warnings all --fqbn $FQBN $EXAMPLE
-done || exit 1
+  ARDUINO_CLI_EXIT_STATUS=$?
+  if [[ $ARDUINO_CLI_EXIT_STATUS -ne 0 ]]; then
+    SCRIPT_EXIT_STATUS=$ARDUINO_CLI_EXIT_STATUS
+  fi
+done
+
+exit $SCRIPT_EXIT_STATUS


### PR DESCRIPTION
Previously, the compile-examples action would only fail if compilation of the last example sketch in `EXAMPLES` failed.

For example, the aentinger/Arduino_MKRMEM run is passing:
https://github.com/aentinger/Arduino_MKRMEM/runs/394646941
but it should not pass, because compilation of the RawFlashAccess example sketch is failing:
https://github.com/aentinger/Arduino_MKRMEM/runs/394646941#step:4:607
```
/github/workspace/examples/RawFlashAccess/RawFlashAccess.ino:33:3: error: 'flash_Id' was not declared in this scope
   flash_Id const id = flash.readId();
   ^~~~~~~~
```

---
Correctly failing aentinger/Arduino_MKRMEM run using the updated action:
https://github.com/per1234/Arduino_MKRMEM/runs/412417957

Correctly passing run using the updated action:
https://github.com/per1234/Arduino_ConnectionHandler/runs/412422223