### PR TITLE
Make compile-examples action support library dependencies with spaces in name

### DIFF
--- a/libraries/compile-examples/entrypoint.sh
+++ b/libraries/compile-examples/entrypoint.sh
@@ -40,7 +40,10 @@ if [ -z "$LIBRARIES" ]
 then
   echo "No libraries to install"
 else
-  arduino-cli lib install $LIBRARIES
+  # Support library names which contain whitespace
+  declare -a -r LIBRARIES_ARRAY="(${LIBRARIES})"
+
+  arduino-cli lib install "${LIBRARIES_ARRAY[@]}"
 fi
 
 # Symlink the library that needs to be built in the sketchbook


### PR DESCRIPTION
In order to install libraries dependencies with spaces in their names, they must be quoted in the `arduino-cli lib install` command, but this was not previously possible.

Running this workflow with the previous `compile-examples` action:
```yaml
on: push

jobs:
  job_1:
    runs-on: ubuntu-latest
    steps:
      - uses: arduino/actions/libraries/compile-examples@master
        with:
          libraries: MKRNB "Arduino Low Power" "Arduino SigFox for MKRFox1200"
```
Fails to install the libraries with spaces in their names:
https://github.com/per1234/test/runs/469473473#step:3:200
```
arduino-cli lib install MKRNB '"Arduino' Low 'Power"' '"Arduino' SigFox for 'MKRFox1200"'
Error resolving dependencies for "Arduino: looking for library: library "Arduino not found
MKRNB depends on MKRNB@1.3.2
Error resolving dependencies for Low: looking for library: library Low not found
Downloading MKRNB@1.3.2...
Error resolving dependencies for Power": looking for library: library Power" not found
Error resolving dependencies for "Arduino: looking for library: library "Arduino not found
Error resolving dependencies for SigFox: looking for library: library SigFox not found
Error resolving dependencies for for: looking for library: library for not found
Error resolving dependencies for MKRFox1200": looking for library: library MKRFox1200" not found
```

Maybe we can fix it by wrapping with single quotes?
```yaml
libraries: '"MKRNB" "Arduino Low Power" "Arduino SigFox for MKRFox1200"'
```
[Nope](https://github.com/per1234/test/runs/469474969#step:3:200):
```
arduino-cli lib install '"MKRNB"' '"Arduino' Low 'Power"' '"Arduino' SigFox for 'MKRFox1200"'
Error resolving dependencies for "MKRNB": looking for library: library "MKRNB" not found
Error resolving dependencies for "Arduino: looking for library: library "Arduino not found
Error resolving dependencies for Low: looking for library: library Low not found
Error resolving dependencies for Power": looking for library: library Power" not found
Error resolving dependencies for "Arduino: looking for library: library "Arduino not found
Error resolving dependencies for SigFox: looking for library: library SigFox not found
Error resolving dependencies for for: looking for library: library for not found
Error resolving dependencies for MKRFox1200": looking for library: library MKRFox1200" not found
```
After the change proposed in this PR, the above [works fine](https://github.com/per1234/test/runs/469476829#step:3:201):
```
arduino-cli lib install MKRNB 'Arduino Low Power' 'Arduino SigFox for MKRFox1200'
MKRNB depends on MKRNB@1.3.2
Arduino Low Power depends on Arduino Low Power@1.2.1
Arduino Low Power depends on RTCZero@1.6.0
Arduino SigFox for MKRFox1200 depends on Arduino SigFox for MKRFox1200@1.0.4
Downloading Arduino SigFox for MKRFox1200@1.0.4...

 0 / 17586    0.00%
Arduino SigFox for MKRFox1200@1.0.4 downloaded
Installing Arduino SigFox for MKRFox1200@1.0.4...
Installed Arduino SigFox for MKRFox1200@1.0.4
Downloading MKRNB@1.3.2...

 0 / 74446    0.00%
MKRNB@1.3.2 downloaded
Installing MKRNB@1.3.2...
Installed MKRNB@1.3.2
Downloading Arduino Low Power@1.2.1...

 0 / 21713    0.00%
Arduino Low Power@1.2.1 downloaded
Installing Arduino Low Power@1.2.1...
Installed Arduino Low Power@1.2.1
Downloading RTCZero@1.6.0...

 0 / 10867    0.00%
RTCZero@1.6.0 downloaded
Installing RTCZero@1.6.0...
Installed RTCZero@1.6.0
```
This is completely backwards compatible with the existing usage of the action with unquoted library names without spaces.