### PR TITLE
Remove incorrect specification that compile-examples' fqbn argument is required

### DIFF
--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -10,7 +10,7 @@ The version of `arduino-cli` to use. Default `"latest"`.
 
 ### `fqbn`
 
-**Required** The fully qualified board name to use when compiling. Default `"arduino:avr:uno"`.
+The fully qualified board name to use when compiling. Default `"arduino:avr:uno"`.
 For 3rd party boards, also specify the Boards Manager URL:
 ```yaml
   fqbn: '"sandeepmistry:nRF5:Generic_nRF52832" "https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json"'

--- a/libraries/compile-examples/action.yml
+++ b/libraries/compile-examples/action.yml
@@ -6,7 +6,6 @@ inputs:
     default: 'latest'
   fqbn:
     description: 'Full qualified board name, with Boards Manager URL if needed'
-    required: true
     default: 'arduino:avr:uno'
   libraries:
     description: 'List of library dependencies to install (space separated)'


### PR DESCRIPTION
Since it has a default value, the `fqbn` argument is not required.