### PR TITLE
Follow best practices in libraries actions scripts

### DIFF
--- a/libraries/compile-examples/Dockerfile
+++ b/libraries/compile-examples/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:latest
 
 # Install prerequisites
-RUN apt-get update --quiet=2 && apt-get install --quiet=2 -y wget
+RUN apt-get update --quiet=2 && apt-get install --quiet=2 --assume-yes wget
 CMD /bin/bash
 
 # Copies your code file from your action repository to the filesystem path `/` of the container

--- a/libraries/compile-examples/entrypoint.sh
+++ b/libraries/compile-examples/entrypoint.sh
@@ -11,19 +11,19 @@ declare -a -r FQBN_ARRAY="(${FQBN_ARG})"
 readonly FQBN="${FQBN_ARRAY[0]}"
 # Extract the core name from the FQBN
 # for example arduino:avr:uno => arduino:avr
-readonly CORE="$(echo "$FQBN" | cut -d':' -f1,2)"
+readonly CORE="$(echo "$FQBN" | cut --delimiter=':' --fields=1,2)"
 
 # Additional Boards Manager URL
 readonly ADDITIONAL_URL="${FQBN_ARRAY[1]}"
 
 # Download the arduino-cli
-wget --no-verbose -P "$HOME" "https://downloads.arduino.cc/arduino-cli/$CLI_ARCHIVE" || {
+wget --no-verbose --directory-prefix="$HOME" "https://downloads.arduino.cc/arduino-cli/$CLI_ARCHIVE" || {
   exit 1
 }
 
 # Extract the arduino-cli to $HOME/bin
 mkdir "$HOME/bin"
-tar xf "$HOME/$CLI_ARCHIVE" -C "$HOME/bin" || {
+tar --extract --file="$HOME/$CLI_ARCHIVE" --directory="$HOME/bin" || {
   exit 1
 }
 
@@ -57,8 +57,8 @@ else
 fi
 
 # Symlink the library that needs to be built in the sketchbook
-mkdir -p "$HOME/Arduino/libraries"
-ln -s "$PWD" "$HOME/Arduino/libraries/."
+mkdir --parents "$HOME/Arduino/libraries"
+ln --symbolic "$PWD" "$HOME/Arduino/libraries/."
 
 # Find all the examples and loop build each
 readonly EXAMPLES="$(find "examples/" -name '*.ino' -print0 | xargs --null dirname | uniq)"

--- a/libraries/compile-examples/entrypoint.sh
+++ b/libraries/compile-examples/entrypoint.sh
@@ -44,8 +44,7 @@ else
 fi
 
 # Install libraries if needed
-if [ -z "$LIBRARIES" ]
-then
+if [ -z "$LIBRARIES" ]; then
   echo "No libraries to install"
 else
   # Support library names which contain whitespace

--- a/libraries/compile-examples/entrypoint.sh
+++ b/libraries/compile-examples/entrypoint.sh
@@ -1,38 +1,38 @@
 #!/bin/bash
 
-CLI_VERSION=$1
-FQBN_ARG=$2
-LIBRARIES=$3
+CLI_VERSION="$1"
+FQBN_ARG="$2"
+LIBRARIES="$3"
 
 # Determine cli archive
-CLI_ARCHIVE=arduino-cli_${CLI_VERSION}_Linux_64bit.tar.gz
+CLI_ARCHIVE="arduino-cli_${CLI_VERSION}_Linux_64bit.tar.gz"
 
 declare -a -r FQBN_ARRAY="(${FQBN_ARG})"
 FQBN="${FQBN_ARRAY[0]}"
 # Extract the core name from the FQBN
 # for example arduino:avr:uno => arduino:avr
-CORE=`echo "$FQBN" | cut -d':' -f1,2`
+CORE="$(echo "$FQBN" | cut -d':' -f1,2)"
 
 # Additional Boards Manager URL
 ADDITIONAL_URL="${FQBN_ARRAY[1]}"
 
 # Download the arduino-cli
-wget --no-verbose -P $HOME https://downloads.arduino.cc/arduino-cli/$CLI_ARCHIVE
+wget --no-verbose -P "$HOME" "https://downloads.arduino.cc/arduino-cli/$CLI_ARCHIVE"
 
 # Extract the arduino-cli to $HOME/bin
-mkdir $HOME/bin
-tar xf $HOME/$CLI_ARCHIVE -C $HOME/bin
+mkdir "$HOME/bin"
+tar xf "$HOME/$CLI_ARCHIVE" -C "$HOME/bin"
 
 # Add arduino-cli to the PATH
-export PATH=$PATH:$HOME/bin
+export PATH="$PATH:$HOME/bin"
 
 # Update the code index and install the required CORE
 if [ -z "$ADDITIONAL_URL" ]; then
   arduino-cli core update-index
-  arduino-cli core install $CORE
+  arduino-cli core install "$CORE"
 else
-  arduino-cli core update-index --additional-urls $ADDITIONAL_URL
-  arduino-cli core install $CORE --additional-urls $ADDITIONAL_URL
+  arduino-cli core update-index --additional-urls "$ADDITIONAL_URL"
+  arduino-cli core install "$CORE" --additional-urls "$ADDITIONAL_URL"
 fi
 
 # Install libraries if needed
@@ -47,16 +47,16 @@ else
 fi
 
 # Symlink the library that needs to be built in the sketchbook
-mkdir -p $HOME/Arduino/libraries
-ln -s $PWD $HOME/Arduino/libraries/.
+mkdir -p "$HOME/Arduino/libraries"
+ln -s "$PWD" "$HOME/Arduino/libraries/."
 
 # Find all the examples and loop build each
-EXAMPLES=`find examples/ -name '*.ino' | xargs dirname | uniq`
+EXAMPLES="$(find "examples/" -name '*.ino' -print0 | xargs --null dirname | uniq)"
 # Set default exit status
 SCRIPT_EXIT_STATUS=0
 for EXAMPLE in $EXAMPLES; do
-  echo Building example $EXAMPLE
-  arduino-cli compile --verbose --warnings all --fqbn $FQBN $EXAMPLE
+  echo "Building example $EXAMPLE"
+  arduino-cli compile --verbose --warnings all --fqbn "$FQBN" "$EXAMPLE"
   ARDUINO_CLI_EXIT_STATUS=$?
   if [[ $ARDUINO_CLI_EXIT_STATUS -ne 0 ]]; then
     SCRIPT_EXIT_STATUS=$ARDUINO_CLI_EXIT_STATUS

--- a/libraries/compile-examples/entrypoint.sh
+++ b/libraries/compile-examples/entrypoint.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-CLI_VERSION="$1"
-FQBN_ARG="$2"
-LIBRARIES="$3"
+readonly CLI_VERSION="$1"
+readonly FQBN_ARG="$2"
+readonly LIBRARIES="$3"
 
 # Determine cli archive
-CLI_ARCHIVE="arduino-cli_${CLI_VERSION}_Linux_64bit.tar.gz"
+readonly CLI_ARCHIVE="arduino-cli_${CLI_VERSION}_Linux_64bit.tar.gz"
 
 declare -a -r FQBN_ARRAY="(${FQBN_ARG})"
-FQBN="${FQBN_ARRAY[0]}"
+readonly FQBN="${FQBN_ARRAY[0]}"
 # Extract the core name from the FQBN
 # for example arduino:avr:uno => arduino:avr
-CORE="$(echo "$FQBN" | cut -d':' -f1,2)"
+readonly CORE="$(echo "$FQBN" | cut -d':' -f1,2)"
 
 # Additional Boards Manager URL
-ADDITIONAL_URL="${FQBN_ARRAY[1]}"
+readonly ADDITIONAL_URL="${FQBN_ARRAY[1]}"
 
 # Download the arduino-cli
 wget --no-verbose -P "$HOME" "https://downloads.arduino.cc/arduino-cli/$CLI_ARCHIVE" || {
@@ -61,7 +61,7 @@ mkdir -p "$HOME/Arduino/libraries"
 ln -s "$PWD" "$HOME/Arduino/libraries/."
 
 # Find all the examples and loop build each
-EXAMPLES="$(find "examples/" -name '*.ino' -print0 | xargs --null dirname | uniq)"
+readonly EXAMPLES="$(find "examples/" -name '*.ino' -print0 | xargs --null dirname | uniq)"
 if [[ "$EXAMPLES" == "" ]]; then
   exit 1
 fi

--- a/libraries/spell-check/Dockerfile
+++ b/libraries/spell-check/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:latest
 
 # Install prerequisites
-RUN apt-get update --quiet=2 && apt-get install --quiet=2 -y python3 python3-pip
+RUN apt-get update --quiet=2 && apt-get install --quiet=2 --assume-yes  python3 python3-pip
 CMD /bin/bash
 
 RUN pip3 install codespell

--- a/libraries/spell-check/entrypoint.sh
+++ b/libraries/spell-check/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IGNORE_WORDS_LIST="$1"
+readonly IGNORE_WORDS_LIST="$1"
 
 CODE_SPELL_ARGS="--skip=.git"
 

--- a/libraries/spell-check/entrypoint.sh
+++ b/libraries/spell-check/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IGNORE_WORDS_LIST=$1
+IGNORE_WORDS_LIST="$1"
 
 CODE_SPELL_ARGS="--skip=.git"
 
@@ -8,4 +8,4 @@ if test -f "$IGNORE_WORDS_LIST"; then
 	CODE_SPELL_ARGS="${CODE_SPELL_ARGS} --ignore-words=${IGNORE_WORDS_LIST}"
 fi
 
-codespell ${CODE_SPELL_ARGS} .
+codespell "${CODE_SPELL_ARGS}" .

--- a/libraries/spell-check/entrypoint.sh
+++ b/libraries/spell-check/entrypoint.sh
@@ -5,7 +5,7 @@ readonly IGNORE_WORDS_LIST="$1"
 CODE_SPELL_ARGS="--skip=.git"
 
 if test -f "$IGNORE_WORDS_LIST"; then
-	CODE_SPELL_ARGS="${CODE_SPELL_ARGS} --ignore-words=${IGNORE_WORDS_LIST}"
+  CODE_SPELL_ARGS="${CODE_SPELL_ARGS} --ignore-words=${IGNORE_WORDS_LIST}"
 fi
 
 codespell "${CODE_SPELL_ARGS}" .


### PR DESCRIPTION
- Make libraries actions scripts [ShellCheck ](https://github.com/koalaman/shellcheck)compliant
- Handle failed commands in compile-examples action
- Make variables readonly where possible in libraries actions
- Use long option names in commands of the libraries actions
- Use [shfmt ](https://github.com/mvdan/sh)to format the libraries actions scripts