### PR TITLE
Link to setup-arduino-cli examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ available to your Workflows.
 
 * [setup-taskfile](./setup-taskfile) makes [Taskfile](https://taskfile.dev/#/)
 available to your Workflows.
+
+[Sample GitHub workflow scripts](https://github.com/ArminJo/Github-Actions) to test compilation of Arduino libraries using the [setup-arduino-cli](https://github.com/arduino/setup-arduino-cli) action.


### PR DESCRIPTION
2 weeks ago I needed a script for test compiling of my Arduino libraries. But I could not find any example around.

So I have to build it by my own, based on your awesome setup-arduino-cli, which took me a few days.

Now I would like to share my result and the best place I guess, is at your repository.
Therefore I added a link to the script in your README.md file.

I would appreciate if you can merge this pull request.
Please tell me if I should change the wording of the, this was a first guess.

Regards
Armin