### PR TITLE
Make libraries/spell-check's CODE_SPELL_ARGS variable an array

### DIFF
--- a/libraries/spell-check/entrypoint.sh
+++ b/libraries/spell-check/entrypoint.sh
@@ -2,10 +2,10 @@
 
 readonly IGNORE_WORDS_LIST="$1"
 
-CODE_SPELL_ARGS="--skip=.git"
+CODE_SPELL_ARGS=(--skip=.git)
 
 if test -f "$IGNORE_WORDS_LIST"; then
-  CODE_SPELL_ARGS="${CODE_SPELL_ARGS} --ignore-words=${IGNORE_WORDS_LIST}"
+  CODE_SPELL_ARGS=("${CODE_SPELL_ARGS[@]}" --ignore-words="${IGNORE_WORDS_LIST}")
 fi
 
-codespell "${CODE_SPELL_ARGS}" .
+codespell "${CODE_SPELL_ARGS[@]}" .


### PR DESCRIPTION
Quoting the non-array variable caused the arguments to not be recognized by codespell. Making it an array fixes this issue, while still providing support for spaces, etc. in the input.