### PR TITLE
libraries/compile-examples: allow sketch paths to be specified

### DIFF
--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -20,6 +20,10 @@ For 3rd party boards, also specify the Boards Manager URL:
 
 List of library dependencies to install (space separated). Default `""`.
 
+### `sketch-paths`
+
+List of paths containing sketches to compile. These paths will be searched recursively. Default `"examples"`.
+
 ### `github-token`
 
 GitHub access token used to get information from the GitHub API. Only needed if you're using the size report features with private repositories. It will be convenient to use [`${{ secrets.GITHUB_TOKEN }}`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token). Default `""`.

--- a/libraries/compile-examples/action.yml
+++ b/libraries/compile-examples/action.yml
@@ -10,6 +10,9 @@ inputs:
   libraries:
     description: 'List of library dependencies to install (space separated)'
     default: ''
+  sketch-paths:
+    description: 'List of paths containing sketches to compile.'
+    default: 'examples'
   github-token:
     description: 'GitHub access token used to get information from the GitHub API. Only needed if you are using the size report features with private repositories.'
     default: ''
@@ -41,6 +44,7 @@ runs:
     - ${{ inputs.cli-version }}
     - ${{ inputs.fqbn }}
     - ${{ inputs.libraries }}
+    - ${{ inputs.sketch-paths }}
     - ${{ inputs.github-token }}
     - ${{ inputs.size-report-sketch }}
     - ${{ inputs.enable-size-deltas-report }}


### PR DESCRIPTION
The previous behavior was to recursively search the `examples` folder for sketches and compile all of them.

The `sketch-paths` input added here allows the user to specify specific paths to search for sketches. The default value of the input is `"examples"` so it is completely backwards compatible.

An example of the application for this feature is when sketches are specific to different boards.

Fixes https://github.com/arduino/actions/issues/24 (note that, after discussion on that issue, we concluded that this was an acceptable alternative to an exclude input).