### PR TITLE
libraries/report-size-deltas: add GitHub Actions workflow to run Python unit tests

### DIFF
--- a/.github/workflows/libraries_report-size-deltas.yml
+++ b/.github/workflows/libraries_report-size-deltas.yml
@@ -1,0 +1,21 @@
+name: libraries/report-size-deltas workflow
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.8.2'
+
+      - name: Run Python unit tests
+        run: |
+          export PYTHONPATH="$GITHUB_WORKSPACE/libraries/report-size-deltas"
+          python -m unittest discover "$GITHUB_WORKSPACE/libraries/report-size-deltas/tests"

--- a/libraries/report-size-deltas/tests/test_reportsizedeltas.py
+++ b/libraries/report-size-deltas/tests/test_reportsizedeltas.py
@@ -196,7 +196,7 @@ class TestReportsizedeltas(unittest.TestCase):
 
         artifact_folder_object = tempfile.TemporaryDirectory(prefix="test_reportsizedeltas-")
         try:
-            distutils.dir_util.copy_tree(src="data/size-deltas-reports", dst=artifact_folder_object.name)
+            distutils.dir_util.copy_tree(src=os.path.dirname(os.path.realpath(__file__)) + "/data/size-deltas-reports", dst=artifact_folder_object.name)
         except Exception:
             artifact_folder_object.cleanup()
             raise


### PR DESCRIPTION
Run the action's unit tests on every PR and push.

I modified one of the unit tests to make it use the absolute path to the test data rather than the relative path. The reason is to avoid having to add an extra line to the workflow file to cd to the test folder.