### PR TITLE
libraries/compile-examples: Demo usage of actions/checkout@v2 and deltas report

### DIFF
--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -106,10 +106,18 @@ Only compiling examples:
 
 Storing the memory usage change report as a [workflow artifact](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts):
 ```yaml
+- uses: actions/checkout@v2
+
+# this step is only required when using actions/checkout@v2 and the size deltas report feature
+- name: Fetch PR base branch
+  if: github.event_name == 'pull_request'
+  run: git fetch --no-tags --prune --depth=1 origin +${{ github.base_ref }}
+
 - uses: arduino/actions/libraries/compile-examples@master
   with:
     size-report-sketch: Foobar
     enable-size-deltas-report: true
+
 - if: github.event_name == 'pull_request'
   uses: actions/upload-artifact@v1
   with:


### PR DESCRIPTION
Unlike `actions/checkout@v1`, the `actions/checkout@v2` action doesn't fetch the PR base branch. In order to determine the memory usage change, `compile-examples` must checkout the PR base branch, so it won't work with a simple usage of `actions/checkout@v2`.

Since it's [now used in GitHub's official documentation](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#using-the-checkout-action), I'm guessing `actions/checkout@v2` will start being widely used. As the solution for using `actions/checkout@v2` with the size deltas report feature of `compile-examples` is not at all obvious, it's worth demonstrating it in the documentation.