### PR TITLE
libraries/compile-examples: fetch PR base ref before checking it out

### DIFF
--- a/libraries/compile-examples/entrypoint.sh
+++ b/libraries/compile-examples/entrypoint.sh
@@ -246,6 +246,7 @@ for SKETCH_PATH in "${SKETCH_PATHS_ARRAY[@]}"; do
           echo "::error::Unable to determine base branch name. Please specify the size-report-github-token argument in your workflow configuration."
           exit 1
         fi
+        git fetch --no-tags --prune --depth=1 origin +"$BASE_BRANCH_NAME"
         git checkout "$BASE_BRANCH_NAME" || {
           echo "::error::Failed to checkout base branch"
           exit 1


### PR DESCRIPTION
Unlike `actions/checkout@v1`, the `actions/checkout@v2` action doesn't fetch the PR base branch. In order to determine the memory usage change, `compile-examples` must checkout the PR base branch. For this reason, before this change the `compile-examples` action with the deltas report feature enabled didn't work with a simple usage of `actions/checkout@v2`.