### PR TITLE
libraries/compile-examples: lint Python code during CI run

### DIFF
--- a/.github/workflows/libraries_compile-examples.yml
+++ b/.github/workflows/libraries_compile-examples.yml
@@ -20,6 +20,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install --requirement "$GITHUB_WORKSPACE/libraries/compile-examples/reportsizetrends/requirements.txt"
 
+      - name: Lint with flake8
+        run: |
+          pip install --quiet flake8
+          pip install --quiet pep8-naming
+          flake8 --show-source "$GITHUB_WORKSPACE/libraries/compile-examples/reportsizetrends"
+
       - name: Run Python unit tests
         run: |
           export PYTHONPATH="$GITHUB_WORKSPACE/libraries/compile-examples/reportsizetrends"

--- a/libraries/compile-examples/reportsizetrends/.flake8
+++ b/libraries/compile-examples/reportsizetrends/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+doctests = True
+max-complexity = 10
+max-line-length = 120
+select = E,W,F,C,N


### PR DESCRIPTION
Use [flake8](https://gitlab.com/pycqa/flake8) to check:
- Formatting compliance with PEP 8 (with the exception of [max line length of 120](https://github.com/arduino/arduino-cli/blob/master/test/.flake8#L3))
- Code style consistency
- Cyclomatic complexity

A configuration file is provided to assist contributors with verifying compliance locally.

---
The linting step of the workflow run is expected to fail due to the Python code currently not being completely compliant with the formatting and style requirements. I will submit additional PRs to fix those issues.