### PR TITLE
libraries/compile-examples: Fix flake8 formatting violations in Python code

### DIFF
--- a/libraries/compile-examples/reportsizetrends/.flake8
+++ b/libraries/compile-examples/reportsizetrends/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 doctests = True
+# W503 and W504 are mutually exclusive. PEP 8 recommends line break before.
+ignore = W503
 max-complexity = 10
 max-line-length = 120
 select = E,W,F,C,N

--- a/libraries/compile-examples/reportsizetrends/reportsizetrends.py
+++ b/libraries/compile-examples/reportsizetrends/reportsizetrends.py
@@ -72,8 +72,8 @@ class ReportSizeTrends:
     shared_data_first_column_letter = timestamp_column_letter
     shared_data_last_column_letter = commit_hash_column_letter
     shared_data_columns_headings_data = (
-            "[[\"" + timestamp_column_heading + "\",\"" + sketch_name_column_heading + "\",\"" +
-            commit_hash_column_heading + "\"]]")
+        "[[\"" + timestamp_column_heading + "\",\"" + sketch_name_column_heading + "\",\"" +
+        commit_hash_column_heading + "\"]]")
 
     # These are appended to the FQBN as the size data column headings
     flash_heading_indicator = " flash"
@@ -146,8 +146,8 @@ class ReportSizeTrends:
     def populate_shared_data_headings(self):
         """Add the headings to the shared data columns (timestamp, sketch name, commit)"""
         spreadsheet_range = (
-                self.sheet_name + "!" + self.shared_data_first_column_letter + self.heading_row_number + ":" +
-                self.shared_data_last_column_letter + self.heading_row_number)
+            self.sheet_name + "!" + self.shared_data_first_column_letter + self.heading_row_number + ":" +
+            self.shared_data_last_column_letter + self.heading_row_number)
         request = self.service.spreadsheets().values().update(spreadsheetId=self.spreadsheet_id,
                                                               range=spreadsheet_range,
                                                               valueInputOption="RAW",

--- a/libraries/compile-examples/reportsizetrends/reportsizetrends.py
+++ b/libraries/compile-examples/reportsizetrends/reportsizetrends.py
@@ -72,8 +72,8 @@ class ReportSizeTrends:
     shared_data_first_column_letter = timestamp_column_letter
     shared_data_last_column_letter = commit_hash_column_letter
     shared_data_columns_headings_data = (
-        "[[\"" + timestamp_column_heading + "\",\"" + sketch_name_column_heading + "\",\"" +
-        commit_hash_column_heading + "\"]]")
+        "[[\"" + timestamp_column_heading + "\",\"" + sketch_name_column_heading + "\",\""
+        + commit_hash_column_heading + "\"]]")
 
     # These are appended to the FQBN as the size data column headings
     flash_heading_indicator = " flash"
@@ -146,8 +146,8 @@ class ReportSizeTrends:
     def populate_shared_data_headings(self):
         """Add the headings to the shared data columns (timestamp, sketch name, commit)"""
         spreadsheet_range = (
-            self.sheet_name + "!" + self.shared_data_first_column_letter + self.heading_row_number + ":" +
-            self.shared_data_last_column_letter + self.heading_row_number)
+            self.sheet_name + "!" + self.shared_data_first_column_letter + self.heading_row_number + ":"
+            + self.shared_data_last_column_letter + self.heading_row_number)
         request = self.service.spreadsheets().values().update(spreadsheetId=self.spreadsheet_id,
                                                               range=spreadsheet_range,
                                                               valueInputOption="RAW",
@@ -189,12 +189,12 @@ class ReportSizeTrends:
         flash_column_letter -- letter of the column that contains the flash usage data
         ram_column_letter -- letter of the column that contains the dynamic memory used by globals data
         """
-        logger.info("No data columns found for " + self.fqbn + ". Adding column headings at columns " +
-                    flash_column_letter + " and " + ram_column_letter)
-        spreadsheet_range = (self.sheet_name + "!" + flash_column_letter + self.heading_row_number + ":" +
-                             ram_column_letter + self.heading_row_number)
-        board_data_headings_data = ("[[\"" + self.fqbn + self.flash_heading_indicator + "\",\"" + self.fqbn +
-                                    self.ram_heading_indicator + "\"]]")
+        logger.info("No data columns found for " + self.fqbn + ". Adding column headings at columns "
+                    + flash_column_letter + " and " + ram_column_letter)
+        spreadsheet_range = (self.sheet_name + "!" + flash_column_letter + self.heading_row_number + ":"
+                             + ram_column_letter + self.heading_row_number)
+        board_data_headings_data = ("[[\"" + self.fqbn + self.flash_heading_indicator + "\",\"" + self.fqbn
+                                    + self.ram_heading_indicator + "\"]]")
         request = self.service.spreadsheets().values().update(spreadsheetId=self.spreadsheet_id,
                                                               range=spreadsheet_range,
                                                               valueInputOption="RAW",
@@ -207,8 +207,8 @@ class ReportSizeTrends:
         populated -- whether the shared data has already been added to the row
         number -- the row number
         """
-        spreadsheet_range = (self.sheet_name + "!" + self.commit_hash_column_letter + ":" +
-                             self.commit_hash_column_letter)
+        spreadsheet_range = (self.sheet_name + "!" + self.commit_hash_column_letter + ":"
+                             + self.commit_hash_column_letter)
         request = self.service.spreadsheets().values().get(spreadsheetId=self.spreadsheet_id,
                                                            range=spreadsheet_range)
         commit_hash_column_data = request.execute()
@@ -233,13 +233,13 @@ class ReportSizeTrends:
         Keyword arguments:
         row_number -- row number
         """
-        logger.info("No row found for the commit hash: " + self.commit_hash + ". Creating a new row #" +
-                    str(row_number))
-        spreadsheet_range = (self.sheet_name + "!" + self.shared_data_first_column_letter + str(row_number) +
-                             ":" + self.shared_data_last_column_letter + str(row_number))
-        shared_data_columns_data = ("[[\"" + "{:%Y-%m-%d %H:%M:%S}".format(datetime.datetime.now()) + "\",\"" +
-                                    self.sketch_name + "\",\"=HYPERLINK(\\\"" + self.commit_url + "\\\",T(\\\"" +
-                                    self.commit_hash + "\\\"))\"]]")
+        logger.info("No row found for the commit hash: " + self.commit_hash + ". Creating a new row #"
+                    + str(row_number))
+        spreadsheet_range = (self.sheet_name + "!" + self.shared_data_first_column_letter + str(row_number)
+                             + ":" + self.shared_data_last_column_letter + str(row_number))
+        shared_data_columns_data = ("[[\"" + "{:%Y-%m-%d %H:%M:%S}".format(datetime.datetime.now()) + "\",\""
+                                    + self.sketch_name + "\",\"=HYPERLINK(\\\"" + self.commit_url + "\\\",T(\\\""
+                                    + self.commit_hash + "\\\"))\"]]")
         request = self.service.spreadsheets().values().update(spreadsheetId=self.spreadsheet_id,
                                                               range=spreadsheet_range,
                                                               valueInputOption="USER_ENTERED",
@@ -257,8 +257,8 @@ class ReportSizeTrends:
         flash -- flash usage
         ram -- dynamic memory used for global variables
         """
-        spreadsheet_range = (self.sheet_name + "!" + flash_column_letter + str(row_number) + ":" +
-                             ram_column_letter + str(row_number))
+        spreadsheet_range = (self.sheet_name + "!" + flash_column_letter + str(row_number) + ":"
+                             + ram_column_letter + str(row_number))
         size_data = "[[" + flash + "," + ram + "]]"
         request = self.service.spreadsheets().values().update(spreadsheetId=self.spreadsheet_id,
                                                               range=spreadsheet_range,

--- a/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
+++ b/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
@@ -139,9 +139,9 @@ class TestReportsizetrends(unittest.TestCase):
 
         report_size_trends.populate_shared_data_headings()
         spreadsheet_range = (
-                sheet_name + "!" + report_size_trends.shared_data_first_column_letter +
-                report_size_trends.heading_row_number + ":" + report_size_trends.shared_data_last_column_letter +
-                report_size_trends.heading_row_number
+            sheet_name + "!" + report_size_trends.shared_data_first_column_letter +
+            report_size_trends.heading_row_number + ":" + report_size_trends.shared_data_last_column_letter +
+            report_size_trends.heading_row_number
         )
         Service.update.assert_called_once_with(
             spreadsheetId=spreadsheet_id,

--- a/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
+++ b/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
@@ -66,11 +66,12 @@ class TestReportsizetrends(unittest.TestCase):
         )
         report_size_trends.get_current_row.assert_called_once()
         report_size_trends.create_row.assert_called_once_with(row_number=current_row["number"])
-        report_size_trends.write_memory_usage_data.assert_called_once_with(flash_column_letter=data_column_letters["flash"],
-                                                                           ram_column_letter=data_column_letters["ram"],
-                                                                           row_number=current_row["number"],
-                                                                           flash=flash,
-                                                                           ram=ram)
+        report_size_trends.write_memory_usage_data.assert_called_once_with(
+            flash_column_letter=data_column_letters["flash"],
+            ram_column_letter=data_column_letters["ram"],
+            row_number=current_row["number"],
+            flash=flash,
+            ram=ram)
 
         # Test populated shared data headings
         heading_row_data = {"values": "foo"}
@@ -292,7 +293,8 @@ class TestReportsizetrends(unittest.TestCase):
         Service.execute = unittest.mock.MagicMock()
         report_size_trends.service = Service()
 
-        report_size_trends.write_memory_usage_data(flash_column_letter=flash_column_letter, ram_column_letter=ram_column_letter,
+        report_size_trends.write_memory_usage_data(flash_column_letter=flash_column_letter,
+                                                   ram_column_letter=ram_column_letter,
                                                    row_number=row_number, flash=flash, ram=ram)
         spreadsheet_range = (sheet_name + "!" + flash_column_letter + str(row_number) + ":" +
                              ram_column_letter + str(row_number))

--- a/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
+++ b/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
@@ -114,8 +114,8 @@ class TestReportsizetrends(unittest.TestCase):
         report_size_trends.service = Service()
 
         self.assertEqual(heading_row_data, report_size_trends.get_heading_row_data())
-        spreadsheet_range = (sheet_name + "!" + report_size_trends.heading_row_number + ":" +
-                             report_size_trends.heading_row_number)
+        spreadsheet_range = (sheet_name + "!" + report_size_trends.heading_row_number + ":"
+                             + report_size_trends.heading_row_number)
         Service.get.assert_called_once_with(spreadsheetId=spreadsheet_id, range=spreadsheet_range)
         Service.execute.assert_called_once()
 
@@ -139,9 +139,9 @@ class TestReportsizetrends(unittest.TestCase):
 
         report_size_trends.populate_shared_data_headings()
         spreadsheet_range = (
-            sheet_name + "!" + report_size_trends.shared_data_first_column_letter +
-            report_size_trends.heading_row_number + ":" + report_size_trends.shared_data_last_column_letter +
-            report_size_trends.heading_row_number
+            sheet_name + "!" + report_size_trends.shared_data_first_column_letter
+            + report_size_trends.heading_row_number + ":" + report_size_trends.shared_data_last_column_letter
+            + report_size_trends.heading_row_number
         )
         Service.update.assert_called_once_with(
             spreadsheetId=spreadsheet_id,
@@ -200,10 +200,10 @@ class TestReportsizetrends(unittest.TestCase):
 
         report_size_trends.populate_data_column_headings(flash_column_letter=flash_column_letter,
                                                          ram_column_letter=ram_column_letter)
-        spreadsheet_range = (sheet_name + "!" + flash_column_letter + report_size_trends.heading_row_number + ":" +
-                             ram_column_letter + report_size_trends.heading_row_number)
-        board_data_headings_data = ("[[\"" + fqbn + report_size_trends.flash_heading_indicator + "\",\"" + fqbn +
-                                    report_size_trends.ram_heading_indicator + "\"]]")
+        spreadsheet_range = (sheet_name + "!" + flash_column_letter + report_size_trends.heading_row_number + ":"
+                             + ram_column_letter + report_size_trends.heading_row_number)
+        board_data_headings_data = ("[[\"" + fqbn + report_size_trends.flash_heading_indicator + "\",\"" + fqbn
+                                    + report_size_trends.ram_heading_indicator + "\"]]")
         Service.update.assert_called_once_with(spreadsheetId=spreadsheet_id,
                                                range=spreadsheet_range,
                                                valueInputOption="RAW",
@@ -229,8 +229,8 @@ class TestReportsizetrends(unittest.TestCase):
         report_size_trends.service = Service()
 
         self.assertEqual({"populated": True, "number": 2}, report_size_trends.get_current_row())
-        spreadsheet_range = (sheet_name + "!" + report_size_trends.commit_hash_column_letter + ":" +
-                             report_size_trends.commit_hash_column_letter)
+        spreadsheet_range = (sheet_name + "!" + report_size_trends.commit_hash_column_letter + ":"
+                             + report_size_trends.commit_hash_column_letter)
         Service.get.assert_called_once_with(spreadsheetId=spreadsheet_id, range=spreadsheet_range)
         Service.execute.assert_called_once()
         Service.execute = unittest.mock.MagicMock(return_value={"values": [["foo"], ["bar"]]})
@@ -259,11 +259,11 @@ class TestReportsizetrends(unittest.TestCase):
         report_size_trends.service = Service()
 
         report_size_trends.create_row(row_number=row_number)
-        spreadsheet_range = (sheet_name + "!" + report_size_trends.shared_data_first_column_letter + str(row_number) +
-                             ":" + report_size_trends.shared_data_last_column_letter + str(row_number))
-        shared_data_columns_data = ("[[\"" + '{:%Y-%m-%d %H:%M:%S}'.format(datetime.datetime.now()) + "\",\"" +
-                                    sketch_name + "\",\"=HYPERLINK(\\\"" + report_size_trends.commit_url +
-                                    "\\\",T(\\\"" + report_size_trends.commit_hash + "\\\"))\"]]")
+        spreadsheet_range = (sheet_name + "!" + report_size_trends.shared_data_first_column_letter + str(row_number)
+                             + ":" + report_size_trends.shared_data_last_column_letter + str(row_number))
+        shared_data_columns_data = ("[[\"" + '{:%Y-%m-%d %H:%M:%S}'.format(datetime.datetime.now()) + "\",\""
+                                    + sketch_name + "\",\"=HYPERLINK(\\\"" + report_size_trends.commit_url
+                                    + "\\\",T(\\\"" + report_size_trends.commit_hash + "\\\"))\"]]")
         Service.update.assert_called_once_with(spreadsheetId=spreadsheet_id,
                                                range=spreadsheet_range,
                                                valueInputOption="USER_ENTERED",
@@ -296,8 +296,8 @@ class TestReportsizetrends(unittest.TestCase):
         report_size_trends.write_memory_usage_data(flash_column_letter=flash_column_letter,
                                                    ram_column_letter=ram_column_letter,
                                                    row_number=row_number, flash=flash, ram=ram)
-        spreadsheet_range = (sheet_name + "!" + flash_column_letter + str(row_number) + ":" +
-                             ram_column_letter + str(row_number))
+        spreadsheet_range = (sheet_name + "!" + flash_column_letter + str(row_number) + ":"
+                             + ram_column_letter + str(row_number))
         size_data = "[[" + flash + "," + ram + "]]"
         Service.update.assert_called_once_with(spreadsheetId=spreadsheet_id,
                                                range=spreadsheet_range,


### PR DESCRIPTION
- Fix lines exceeding max length
- Fix over-indented continuation lines
- Use line break before binary operators

NOTE: CI continues to fail due to a separate class of flake8 violations. I will fix those issues in a separate PR.