### PR TITLE
libraries/compile-examples: switch to using pytest for unit testing framework

### DIFF
--- a/.github/workflows/libraries_compile-examples.yml
+++ b/.github/workflows/libraries_compile-examples.yml
@@ -32,4 +32,4 @@ jobs:
         run: |
           export PYTHONPATH="$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches:$GITHUB_WORKSPACE/libraries/compile-examples/reportsizetrends"
           pytest "$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches/tests"
-          python -m unittest discover "$GITHUB_WORKSPACE/libraries/compile-examples/reportsizetrends/tests"
+          pytest "$GITHUB_WORKSPACE/libraries/compile-examples/reportsizetrends/tests"

--- a/libraries/compile-examples/reportsizetrends/requirements.txt
+++ b/libraries/compile-examples/reportsizetrends/requirements.txt
@@ -1,2 +1,3 @@
 google-auth~=1.11
 google-api-python-client~=1.7
+pytest==5.4.1

--- a/libraries/compile-examples/reportsizetrends/tests/pytest.ini
+++ b/libraries/compile-examples/reportsizetrends/tests/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+filterwarnings =
+    error
+    ignore::DeprecationWarning
+    ignore::ResourceWarning
+
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
+++ b/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
@@ -2,6 +2,8 @@ import datetime
 import json
 import unittest.mock
 
+import pytest
+
 import reportsizetrends
 
 
@@ -24,7 +26,7 @@ class TestReportsizetrends(unittest.TestCase):
 
     # @unittest.skip("")
     def test_set_verbosity(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             reportsizetrends.set_verbosity(enable_verbosity=2)
         reportsizetrends.set_verbosity(enable_verbosity=True)
         reportsizetrends.set_verbosity(enable_verbosity=False)
@@ -116,7 +118,7 @@ class TestReportsizetrends(unittest.TestCase):
         Service.execute = unittest.mock.MagicMock(return_value=heading_row_data)
         report_size_trends.service = Service()
 
-        self.assertEqual(heading_row_data, report_size_trends.get_heading_row_data())
+        assert heading_row_data == report_size_trends.get_heading_row_data()
         spreadsheet_range = (sheet_name + "!" + report_size_trends.heading_row_number + ":"
                              + report_size_trends.heading_row_number)
         Service.get.assert_called_once_with(spreadsheetId=spreadsheet_id, range=spreadsheet_range)
@@ -170,15 +172,15 @@ class TestReportsizetrends(unittest.TestCase):
                                                                ram=11)
         heading_row_data = {"values": [["foo", "bar"]]}
         column_letters = report_size_trends.get_data_column_letters(heading_row_data)
-        self.assertEqual(False, column_letters["populated"])
-        self.assertEqual("C", column_letters["flash"])
-        self.assertEqual("D", column_letters["ram"])
+        assert column_letters["populated"] is False
+        assert "C" == column_letters["flash"]
+        assert "D" == column_letters["ram"]
 
         heading_row_data = {"values": [["foo", report_size_trends.fqbn + report_size_trends.flash_heading_indicator]]}
         column_letters = report_size_trends.get_data_column_letters(heading_row_data)
-        self.assertEqual(True, column_letters["populated"])
-        self.assertEqual("B", column_letters["flash"])
-        self.assertEqual("C", column_letters["ram"])
+        assert column_letters["populated"] is True
+        assert "B" == column_letters["flash"]
+        assert "C" == column_letters["ram"]
 
     # @unittest.skip("")
     def test_populate_data_column_headings(self):
@@ -231,13 +233,13 @@ class TestReportsizetrends(unittest.TestCase):
         Service.execute = unittest.mock.MagicMock(return_value={"values": [["foo"], [commit_hash]]})
         report_size_trends.service = Service()
 
-        self.assertEqual({"populated": True, "number": 2}, report_size_trends.get_current_row())
+        assert {"populated": True, "number": 2} == report_size_trends.get_current_row()
         spreadsheet_range = (sheet_name + "!" + report_size_trends.commit_hash_column_letter + ":"
                              + report_size_trends.commit_hash_column_letter)
         Service.get.assert_called_once_with(spreadsheetId=spreadsheet_id, range=spreadsheet_range)
         Service.execute.assert_called_once()
         Service.execute = unittest.mock.MagicMock(return_value={"values": [["foo"], ["bar"]]})
-        self.assertEqual({"populated": False, "number": 3}, report_size_trends.get_current_row())
+        assert {"populated": False, "number": 3} == report_size_trends.get_current_row()
 
     # @unittest.skip("")
     def test_create_row(self):

--- a/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
+++ b/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
@@ -20,287 +20,291 @@ class Service:
         return Service()
 
 
-# noinspection PyUnresolvedReferences
-class TestReportsizetrends(unittest.TestCase):
+reportsizetrends.set_verbosity(enable_verbosity=False)
+
+
+def test_set_verbosity():
+    with pytest.raises(TypeError):
+        reportsizetrends.set_verbosity(enable_verbosity=2)
+    reportsizetrends.set_verbosity(enable_verbosity=True)
     reportsizetrends.set_verbosity(enable_verbosity=False)
 
-    def test_set_verbosity(self):
-        with pytest.raises(TypeError):
-            reportsizetrends.set_verbosity(enable_verbosity=2)
-        reportsizetrends.set_verbosity(enable_verbosity=True)
-        reportsizetrends.set_verbosity(enable_verbosity=False)
 
-    def test_report_size_trends(self):
-        google_key_file = "test_google_key_file"
-        flash = 42
-        ram = 11
-        heading_row_data = {}
-        current_row = {"populated": False, "number": 42}
-        data_column_letters = {"populated": False, "flash": "A", "ram": "B"}
-        report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file=google_key_file,
-                                                               spreadsheet_id="foo",
-                                                               sheet_name="foo",
-                                                               sketch_name="foo",
-                                                               commit_hash="foo",
-                                                               commit_url="foo",
-                                                               fqbn="foo",
-                                                               flash=flash,
-                                                               ram=ram)
+# noinspection PyUnresolvedReferences
+def test_report_size_trends():
+    google_key_file = "test_google_key_file"
+    flash = 42
+    ram = 11
+    heading_row_data = {}
+    current_row = {"populated": False, "number": 42}
+    data_column_letters = {"populated": False, "flash": "A", "ram": "B"}
+    report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file=google_key_file,
+                                                           spreadsheet_id="foo",
+                                                           sheet_name="foo",
+                                                           sketch_name="foo",
+                                                           commit_hash="foo",
+                                                           commit_url="foo",
+                                                           fqbn="foo",
+                                                           flash=flash,
+                                                           ram=ram)
 
-        report_size_trends.get_service = unittest.mock.MagicMock()
-        report_size_trends.get_heading_row_data = unittest.mock.MagicMock(return_value=heading_row_data)
-        report_size_trends.populate_shared_data_headings = unittest.mock.MagicMock()
-        report_size_trends.get_data_column_letters = unittest.mock.MagicMock(return_value=data_column_letters)
-        report_size_trends.populate_data_column_headings = unittest.mock.MagicMock()
-        report_size_trends.get_current_row = unittest.mock.MagicMock(return_value=current_row)
-        report_size_trends.create_row = unittest.mock.MagicMock()
-        report_size_trends.write_memory_usage_data = unittest.mock.MagicMock()
+    report_size_trends.get_service = unittest.mock.MagicMock()
+    report_size_trends.get_heading_row_data = unittest.mock.MagicMock(return_value=heading_row_data)
+    report_size_trends.populate_shared_data_headings = unittest.mock.MagicMock()
+    report_size_trends.get_data_column_letters = unittest.mock.MagicMock(return_value=data_column_letters)
+    report_size_trends.populate_data_column_headings = unittest.mock.MagicMock()
+    report_size_trends.get_current_row = unittest.mock.MagicMock(return_value=current_row)
+    report_size_trends.create_row = unittest.mock.MagicMock()
+    report_size_trends.write_memory_usage_data = unittest.mock.MagicMock()
 
-        # Test unpopulated shared data headings
-        report_size_trends.report_size_trends()
+    # Test unpopulated shared data headings
+    report_size_trends.report_size_trends()
 
-        report_size_trends.get_service.assert_called_once_with(google_key_file=google_key_file)
-        report_size_trends.get_heading_row_data.assert_has_calls([unittest.mock.call(), unittest.mock.call()])
-        report_size_trends.populate_shared_data_headings.assert_called_once()
-        report_size_trends.get_data_column_letters.assert_called_once_with(heading_row_data=heading_row_data)
-        report_size_trends.populate_data_column_headings.assert_called_once_with(
-            flash_column_letter=data_column_letters["flash"],
-            ram_column_letter=data_column_letters["ram"]
-        )
-        report_size_trends.get_current_row.assert_called_once()
-        report_size_trends.create_row.assert_called_once_with(row_number=current_row["number"])
-        report_size_trends.write_memory_usage_data.assert_called_once_with(
-            flash_column_letter=data_column_letters["flash"],
-            ram_column_letter=data_column_letters["ram"],
-            row_number=current_row["number"],
-            flash=flash,
-            ram=ram)
+    report_size_trends.get_service.assert_called_once_with(google_key_file=google_key_file)
+    report_size_trends.get_heading_row_data.assert_has_calls([unittest.mock.call(), unittest.mock.call()])
+    report_size_trends.populate_shared_data_headings.assert_called_once()
+    report_size_trends.get_data_column_letters.assert_called_once_with(heading_row_data=heading_row_data)
+    report_size_trends.populate_data_column_headings.assert_called_once_with(
+        flash_column_letter=data_column_letters["flash"],
+        ram_column_letter=data_column_letters["ram"]
+    )
+    report_size_trends.get_current_row.assert_called_once()
+    report_size_trends.create_row.assert_called_once_with(row_number=current_row["number"])
+    report_size_trends.write_memory_usage_data.assert_called_once_with(
+        flash_column_letter=data_column_letters["flash"],
+        ram_column_letter=data_column_letters["ram"],
+        row_number=current_row["number"],
+        flash=flash,
+        ram=ram)
 
-        # Test populated shared data headings
-        heading_row_data = {"values": "foo"}
-        report_size_trends.get_heading_row_data = unittest.mock.MagicMock(return_value=heading_row_data)
-        report_size_trends.populate_shared_data_headings.reset_mock()
-        report_size_trends.report_size_trends()
-        report_size_trends.populate_shared_data_headings.assert_not_called()
+    # Test populated shared data headings
+    heading_row_data = {"values": "foo"}
+    report_size_trends.get_heading_row_data = unittest.mock.MagicMock(return_value=heading_row_data)
+    report_size_trends.populate_shared_data_headings.reset_mock()
+    report_size_trends.report_size_trends()
+    report_size_trends.populate_shared_data_headings.assert_not_called()
 
-        # Test pre-populated data column headings
-        data_column_letters["populated"] = True
-        report_size_trends.get_data_column_letters = unittest.mock.MagicMock(return_value=data_column_letters)
-        report_size_trends.populate_data_column_headings.reset_mock()
-        report_size_trends.report_size_trends()
-        report_size_trends.populate_data_column_headings.assert_not_called()
+    # Test pre-populated data column headings
+    data_column_letters["populated"] = True
+    report_size_trends.get_data_column_letters = unittest.mock.MagicMock(return_value=data_column_letters)
+    report_size_trends.populate_data_column_headings.reset_mock()
+    report_size_trends.report_size_trends()
+    report_size_trends.populate_data_column_headings.assert_not_called()
 
-        # Test pre-populated row
-        current_row["populated"] = True
-        report_size_trends.get_current_row = unittest.mock.MagicMock(return_value=current_row)
-        report_size_trends.create_row.reset_mock()
-        report_size_trends.report_size_trends()
-        report_size_trends.create_row.assert_not_called()
-
-    def test_get_heading_row_data(self):
-        spreadsheet_id = "test_spreadsheet_id"
-        sheet_name = "test_sheet_name"
-        report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
-                                                               spreadsheet_id=spreadsheet_id,
-                                                               sheet_name=sheet_name,
-                                                               sketch_name="foo",
-                                                               commit_hash="foo",
-                                                               commit_url="foo",
-                                                               fqbn="foo",
-                                                               flash=42,
-                                                               ram=11)
-        heading_row_data = "test_heading_row_data"
-
-        Service.get = unittest.mock.MagicMock(return_value=Service())
-        Service.execute = unittest.mock.MagicMock(return_value=heading_row_data)
-        report_size_trends.service = Service()
-
-        assert heading_row_data == report_size_trends.get_heading_row_data()
-        spreadsheet_range = (sheet_name + "!" + report_size_trends.heading_row_number + ":"
-                             + report_size_trends.heading_row_number)
-        Service.get.assert_called_once_with(spreadsheetId=spreadsheet_id, range=spreadsheet_range)
-        Service.execute.assert_called_once()
-
-    def test_populate_shared_data_headings(self):
-        spreadsheet_id = "test_spreadsheet_id"
-        sheet_name = "test_sheet_name"
-        report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
-                                                               spreadsheet_id=spreadsheet_id,
-                                                               sheet_name=sheet_name,
-                                                               sketch_name="foo",
-                                                               commit_hash="foo",
-                                                               commit_url="foo",
-                                                               fqbn="foo",
-                                                               flash=42,
-                                                               ram=11)
-
-        Service.update = unittest.mock.MagicMock(return_value=Service())
-        Service.execute = unittest.mock.MagicMock()
-        report_size_trends.service = Service()
-
-        report_size_trends.populate_shared_data_headings()
-        spreadsheet_range = (
-            sheet_name + "!" + report_size_trends.shared_data_first_column_letter
-            + report_size_trends.heading_row_number + ":" + report_size_trends.shared_data_last_column_letter
-            + report_size_trends.heading_row_number
-        )
-        Service.update.assert_called_once_with(
-            spreadsheetId=spreadsheet_id,
-            range=spreadsheet_range,
-            valueInputOption="RAW",
-            body={"values": json.loads(
-                report_size_trends.shared_data_columns_headings_data)}
-        )
-        Service.execute.assert_called_once()
-
-    def test_get_data_column_letters(self):
-        fqbn = "test_fqbn"
-
-        report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
-                                                               spreadsheet_id="foo",
-                                                               sheet_name="foo",
-                                                               sketch_name="foo",
-                                                               commit_hash="foo",
-                                                               commit_url="foo",
-                                                               fqbn=fqbn,
-                                                               flash=42,
-                                                               ram=11)
-        heading_row_data = {"values": [["foo", "bar"]]}
-        column_letters = report_size_trends.get_data_column_letters(heading_row_data)
-        assert column_letters["populated"] is False
-        assert "C" == column_letters["flash"]
-        assert "D" == column_letters["ram"]
-
-        heading_row_data = {"values": [["foo", report_size_trends.fqbn + report_size_trends.flash_heading_indicator]]}
-        column_letters = report_size_trends.get_data_column_letters(heading_row_data)
-        assert column_letters["populated"] is True
-        assert "B" == column_letters["flash"]
-        assert "C" == column_letters["ram"]
-
-    def test_populate_data_column_headings(self):
-        spreadsheet_id = "test_spreadsheet_id"
-        sheet_name = "test_sheet_name"
-        fqbn = "test_fqbn"
-        report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
-                                                               spreadsheet_id=spreadsheet_id,
-                                                               sheet_name=sheet_name,
-                                                               sketch_name="foo",
-                                                               commit_hash="foo",
-                                                               commit_url="foo",
-                                                               fqbn=fqbn,
-                                                               flash=42,
-                                                               ram=11)
-        flash_column_letter = "A"
-        ram_column_letter = "B"
-
-        Service.update = unittest.mock.MagicMock(return_value=Service())
-        Service.execute = unittest.mock.MagicMock()
-        report_size_trends.service = Service()
-
-        report_size_trends.populate_data_column_headings(flash_column_letter=flash_column_letter,
-                                                         ram_column_letter=ram_column_letter)
-        spreadsheet_range = (sheet_name + "!" + flash_column_letter + report_size_trends.heading_row_number + ":"
-                             + ram_column_letter + report_size_trends.heading_row_number)
-        board_data_headings_data = ("[[\"" + fqbn + report_size_trends.flash_heading_indicator + "\",\"" + fqbn
-                                    + report_size_trends.ram_heading_indicator + "\"]]")
-        Service.update.assert_called_once_with(spreadsheetId=spreadsheet_id,
-                                               range=spreadsheet_range,
-                                               valueInputOption="RAW",
-                                               body={"values": json.loads(board_data_headings_data)})
-        Service.execute.assert_called_once()
-
-    def test_get_current_row(self):
-        spreadsheet_id = "test_spreadsheet_id"
-        sheet_name = "test_sheet_name"
-        commit_hash = "test_commit_hash"
-        report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
-                                                               spreadsheet_id=spreadsheet_id,
-                                                               sheet_name=sheet_name,
-                                                               sketch_name="foo",
-                                                               commit_hash=commit_hash,
-                                                               commit_url="foo",
-                                                               fqbn="foo",
-                                                               flash=42,
-                                                               ram=11)
-        Service.get = unittest.mock.MagicMock(return_value=Service())
-        Service.execute = unittest.mock.MagicMock(return_value={"values": [["foo"], [commit_hash]]})
-        report_size_trends.service = Service()
-
-        assert {"populated": True, "number": 2} == report_size_trends.get_current_row()
-        spreadsheet_range = (sheet_name + "!" + report_size_trends.commit_hash_column_letter + ":"
-                             + report_size_trends.commit_hash_column_letter)
-        Service.get.assert_called_once_with(spreadsheetId=spreadsheet_id, range=spreadsheet_range)
-        Service.execute.assert_called_once()
-        Service.execute = unittest.mock.MagicMock(return_value={"values": [["foo"], ["bar"]]})
-        assert {"populated": False, "number": 3} == report_size_trends.get_current_row()
-
-    def test_create_row(self):
-        spreadsheet_id = "test_spreadsheet_id"
-        sheet_name = "test_sheet_name"
-        sketch_name = "test_sketch_name"
-        fqbn = "test_fqbn"
-        commit_url = "test_commit_url"
-        report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
-                                                               spreadsheet_id=spreadsheet_id,
-                                                               sheet_name=sheet_name,
-                                                               sketch_name=sketch_name,
-                                                               commit_hash="foo",
-                                                               commit_url=commit_url,
-                                                               fqbn=fqbn,
-                                                               flash=42,
-                                                               ram=11)
-        row_number = 42
-
-        Service.update = unittest.mock.MagicMock(return_value=Service())
-        Service.execute = unittest.mock.MagicMock()
-        report_size_trends.service = Service()
-
-        report_size_trends.create_row(row_number=row_number)
-        spreadsheet_range = (sheet_name + "!" + report_size_trends.shared_data_first_column_letter + str(row_number)
-                             + ":" + report_size_trends.shared_data_last_column_letter + str(row_number))
-        shared_data_columns_data = ("[[\"" + '{:%Y-%m-%d %H:%M:%S}'.format(datetime.datetime.now()) + "\",\""
-                                    + sketch_name + "\",\"=HYPERLINK(\\\"" + report_size_trends.commit_url
-                                    + "\\\",T(\\\"" + report_size_trends.commit_hash + "\\\"))\"]]")
-        Service.update.assert_called_once_with(spreadsheetId=spreadsheet_id,
-                                               range=spreadsheet_range,
-                                               valueInputOption="USER_ENTERED",
-                                               body={"values": json.loads(shared_data_columns_data)})
-        Service.execute.assert_called_once()
-
-    def test_write_memory_usage_data(self):
-        spreadsheet_id = "test_spreadsheet_id"
-        sheet_name = "test_sheet_name"
-        report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
-                                                               spreadsheet_id=spreadsheet_id,
-                                                               sheet_name=sheet_name,
-                                                               sketch_name="foo",
-                                                               commit_hash="foo",
-                                                               commit_url="foo",
-                                                               fqbn="foo",
-                                                               flash=42,
-                                                               ram=11)
-        flash_column_letter = "A"
-        ram_column_letter = "B"
-        row_number = 42
-        flash = "11"
-        ram = "12"
-
-        Service.update = unittest.mock.MagicMock(return_value=Service())
-        Service.execute = unittest.mock.MagicMock()
-        report_size_trends.service = Service()
-
-        report_size_trends.write_memory_usage_data(flash_column_letter=flash_column_letter,
-                                                   ram_column_letter=ram_column_letter,
-                                                   row_number=row_number, flash=flash, ram=ram)
-        spreadsheet_range = (sheet_name + "!" + flash_column_letter + str(row_number) + ":"
-                             + ram_column_letter + str(row_number))
-        size_data = "[[" + flash + "," + ram + "]]"
-        Service.update.assert_called_once_with(spreadsheetId=spreadsheet_id,
-                                               range=spreadsheet_range,
-                                               valueInputOption="RAW",
-                                               body={"values": json.loads(size_data)})
-        Service.execute.assert_called_once()
+    # Test pre-populated row
+    current_row["populated"] = True
+    report_size_trends.get_current_row = unittest.mock.MagicMock(return_value=current_row)
+    report_size_trends.create_row.reset_mock()
+    report_size_trends.report_size_trends()
+    report_size_trends.create_row.assert_not_called()
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_get_heading_row_data():
+    spreadsheet_id = "test_spreadsheet_id"
+    sheet_name = "test_sheet_name"
+    report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
+                                                           spreadsheet_id=spreadsheet_id,
+                                                           sheet_name=sheet_name,
+                                                           sketch_name="foo",
+                                                           commit_hash="foo",
+                                                           commit_url="foo",
+                                                           fqbn="foo",
+                                                           flash=42,
+                                                           ram=11)
+    heading_row_data = "test_heading_row_data"
+
+    Service.get = unittest.mock.MagicMock(return_value=Service())
+    Service.execute = unittest.mock.MagicMock(return_value=heading_row_data)
+    report_size_trends.service = Service()
+
+    assert heading_row_data == report_size_trends.get_heading_row_data()
+    spreadsheet_range = (sheet_name + "!" + report_size_trends.heading_row_number + ":"
+                         + report_size_trends.heading_row_number)
+    Service.get.assert_called_once_with(spreadsheetId=spreadsheet_id, range=spreadsheet_range)
+    Service.execute.assert_called_once()
+
+
+def test_populate_shared_data_headings():
+    spreadsheet_id = "test_spreadsheet_id"
+    sheet_name = "test_sheet_name"
+    report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
+                                                           spreadsheet_id=spreadsheet_id,
+                                                           sheet_name=sheet_name,
+                                                           sketch_name="foo",
+                                                           commit_hash="foo",
+                                                           commit_url="foo",
+                                                           fqbn="foo",
+                                                           flash=42,
+                                                           ram=11)
+
+    Service.update = unittest.mock.MagicMock(return_value=Service())
+    Service.execute = unittest.mock.MagicMock()
+    report_size_trends.service = Service()
+
+    report_size_trends.populate_shared_data_headings()
+    spreadsheet_range = (
+        sheet_name + "!" + report_size_trends.shared_data_first_column_letter
+        + report_size_trends.heading_row_number + ":" + report_size_trends.shared_data_last_column_letter
+        + report_size_trends.heading_row_number
+    )
+    Service.update.assert_called_once_with(
+        spreadsheetId=spreadsheet_id,
+        range=spreadsheet_range,
+        valueInputOption="RAW",
+        body={"values": json.loads(
+            report_size_trends.shared_data_columns_headings_data)}
+    )
+    Service.execute.assert_called_once()
+
+
+def test_get_data_column_letters():
+    fqbn = "test_fqbn"
+
+    report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
+                                                           spreadsheet_id="foo",
+                                                           sheet_name="foo",
+                                                           sketch_name="foo",
+                                                           commit_hash="foo",
+                                                           commit_url="foo",
+                                                           fqbn=fqbn,
+                                                           flash=42,
+                                                           ram=11)
+    heading_row_data = {"values": [["foo", "bar"]]}
+    column_letters = report_size_trends.get_data_column_letters(heading_row_data)
+    assert column_letters["populated"] is False
+    assert "C" == column_letters["flash"]
+    assert "D" == column_letters["ram"]
+
+    heading_row_data = {"values": [["foo", report_size_trends.fqbn + report_size_trends.flash_heading_indicator]]}
+    column_letters = report_size_trends.get_data_column_letters(heading_row_data)
+    assert column_letters["populated"] is True
+    assert "B" == column_letters["flash"]
+    assert "C" == column_letters["ram"]
+
+
+def test_populate_data_column_headings():
+    spreadsheet_id = "test_spreadsheet_id"
+    sheet_name = "test_sheet_name"
+    fqbn = "test_fqbn"
+    report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
+                                                           spreadsheet_id=spreadsheet_id,
+                                                           sheet_name=sheet_name,
+                                                           sketch_name="foo",
+                                                           commit_hash="foo",
+                                                           commit_url="foo",
+                                                           fqbn=fqbn,
+                                                           flash=42,
+                                                           ram=11)
+    flash_column_letter = "A"
+    ram_column_letter = "B"
+
+    Service.update = unittest.mock.MagicMock(return_value=Service())
+    Service.execute = unittest.mock.MagicMock()
+    report_size_trends.service = Service()
+
+    report_size_trends.populate_data_column_headings(flash_column_letter=flash_column_letter,
+                                                     ram_column_letter=ram_column_letter)
+    spreadsheet_range = (sheet_name + "!" + flash_column_letter + report_size_trends.heading_row_number + ":"
+                         + ram_column_letter + report_size_trends.heading_row_number)
+    board_data_headings_data = ("[[\"" + fqbn + report_size_trends.flash_heading_indicator + "\",\"" + fqbn
+                                + report_size_trends.ram_heading_indicator + "\"]]")
+    Service.update.assert_called_once_with(spreadsheetId=spreadsheet_id,
+                                           range=spreadsheet_range,
+                                           valueInputOption="RAW",
+                                           body={"values": json.loads(board_data_headings_data)})
+    Service.execute.assert_called_once()
+
+
+def test_get_current_row():
+    spreadsheet_id = "test_spreadsheet_id"
+    sheet_name = "test_sheet_name"
+    commit_hash = "test_commit_hash"
+    report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
+                                                           spreadsheet_id=spreadsheet_id,
+                                                           sheet_name=sheet_name,
+                                                           sketch_name="foo",
+                                                           commit_hash=commit_hash,
+                                                           commit_url="foo",
+                                                           fqbn="foo",
+                                                           flash=42,
+                                                           ram=11)
+    Service.get = unittest.mock.MagicMock(return_value=Service())
+    Service.execute = unittest.mock.MagicMock(return_value={"values": [["foo"], [commit_hash]]})
+    report_size_trends.service = Service()
+
+    assert {"populated": True, "number": 2} == report_size_trends.get_current_row()
+    spreadsheet_range = (sheet_name + "!" + report_size_trends.commit_hash_column_letter + ":"
+                         + report_size_trends.commit_hash_column_letter)
+    Service.get.assert_called_once_with(spreadsheetId=spreadsheet_id, range=spreadsheet_range)
+    Service.execute.assert_called_once()
+    Service.execute = unittest.mock.MagicMock(return_value={"values": [["foo"], ["bar"]]})
+    assert {"populated": False, "number": 3} == report_size_trends.get_current_row()
+
+
+def test_create_row():
+    spreadsheet_id = "test_spreadsheet_id"
+    sheet_name = "test_sheet_name"
+    sketch_name = "test_sketch_name"
+    fqbn = "test_fqbn"
+    commit_url = "test_commit_url"
+    report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
+                                                           spreadsheet_id=spreadsheet_id,
+                                                           sheet_name=sheet_name,
+                                                           sketch_name=sketch_name,
+                                                           commit_hash="foo",
+                                                           commit_url=commit_url,
+                                                           fqbn=fqbn,
+                                                           flash=42,
+                                                           ram=11)
+    row_number = 42
+
+    Service.update = unittest.mock.MagicMock(return_value=Service())
+    Service.execute = unittest.mock.MagicMock()
+    report_size_trends.service = Service()
+
+    report_size_trends.create_row(row_number=row_number)
+    spreadsheet_range = (sheet_name + "!" + report_size_trends.shared_data_first_column_letter + str(row_number)
+                         + ":" + report_size_trends.shared_data_last_column_letter + str(row_number))
+    shared_data_columns_data = ("[[\"" + '{:%Y-%m-%d %H:%M:%S}'.format(datetime.datetime.now()) + "\",\""
+                                + sketch_name + "\",\"=HYPERLINK(\\\"" + report_size_trends.commit_url
+                                + "\\\",T(\\\"" + report_size_trends.commit_hash + "\\\"))\"]]")
+    Service.update.assert_called_once_with(spreadsheetId=spreadsheet_id,
+                                           range=spreadsheet_range,
+                                           valueInputOption="USER_ENTERED",
+                                           body={"values": json.loads(shared_data_columns_data)})
+    Service.execute.assert_called_once()
+
+
+def test_write_memory_usage_data():
+    spreadsheet_id = "test_spreadsheet_id"
+    sheet_name = "test_sheet_name"
+    report_size_trends = reportsizetrends.ReportSizeTrends(google_key_file="foo",
+                                                           spreadsheet_id=spreadsheet_id,
+                                                           sheet_name=sheet_name,
+                                                           sketch_name="foo",
+                                                           commit_hash="foo",
+                                                           commit_url="foo",
+                                                           fqbn="foo",
+                                                           flash=42,
+                                                           ram=11)
+    flash_column_letter = "A"
+    ram_column_letter = "B"
+    row_number = 42
+    flash = "11"
+    ram = "12"
+
+    Service.update = unittest.mock.MagicMock(return_value=Service())
+    Service.execute = unittest.mock.MagicMock()
+    report_size_trends.service = Service()
+
+    report_size_trends.write_memory_usage_data(flash_column_letter=flash_column_letter,
+                                               ram_column_letter=ram_column_letter,
+                                               row_number=row_number, flash=flash, ram=ram)
+    spreadsheet_range = (sheet_name + "!" + flash_column_letter + str(row_number) + ":"
+                         + ram_column_letter + str(row_number))
+    size_data = "[[" + flash + "," + ram + "]]"
+    Service.update.assert_called_once_with(spreadsheetId=spreadsheet_id,
+                                           range=spreadsheet_range,
+                                           valueInputOption="RAW",
+                                           body={"values": json.loads(size_data)})
+    Service.execute.assert_called_once()

--- a/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
+++ b/libraries/compile-examples/reportsizetrends/tests/test_reportsizetrends.py
@@ -24,14 +24,12 @@ class Service:
 class TestReportsizetrends(unittest.TestCase):
     reportsizetrends.set_verbosity(enable_verbosity=False)
 
-    # @unittest.skip("")
     def test_set_verbosity(self):
         with pytest.raises(TypeError):
             reportsizetrends.set_verbosity(enable_verbosity=2)
         reportsizetrends.set_verbosity(enable_verbosity=True)
         reportsizetrends.set_verbosity(enable_verbosity=False)
 
-    # @unittest.skip("")
     def test_report_size_trends(self):
         google_key_file = "test_google_key_file"
         flash = 42
@@ -99,7 +97,6 @@ class TestReportsizetrends(unittest.TestCase):
         report_size_trends.report_size_trends()
         report_size_trends.create_row.assert_not_called()
 
-    # @unittest.skip("")
     def test_get_heading_row_data(self):
         spreadsheet_id = "test_spreadsheet_id"
         sheet_name = "test_sheet_name"
@@ -124,7 +121,6 @@ class TestReportsizetrends(unittest.TestCase):
         Service.get.assert_called_once_with(spreadsheetId=spreadsheet_id, range=spreadsheet_range)
         Service.execute.assert_called_once()
 
-    # @unittest.skip("")
     def test_populate_shared_data_headings(self):
         spreadsheet_id = "test_spreadsheet_id"
         sheet_name = "test_sheet_name"
@@ -157,7 +153,6 @@ class TestReportsizetrends(unittest.TestCase):
         )
         Service.execute.assert_called_once()
 
-    # @unittest.skip("")
     def test_get_data_column_letters(self):
         fqbn = "test_fqbn"
 
@@ -182,7 +177,6 @@ class TestReportsizetrends(unittest.TestCase):
         assert "B" == column_letters["flash"]
         assert "C" == column_letters["ram"]
 
-    # @unittest.skip("")
     def test_populate_data_column_headings(self):
         spreadsheet_id = "test_spreadsheet_id"
         sheet_name = "test_sheet_name"
@@ -215,7 +209,6 @@ class TestReportsizetrends(unittest.TestCase):
                                                body={"values": json.loads(board_data_headings_data)})
         Service.execute.assert_called_once()
 
-    # @unittest.skip("")
     def test_get_current_row(self):
         spreadsheet_id = "test_spreadsheet_id"
         sheet_name = "test_sheet_name"
@@ -241,7 +234,6 @@ class TestReportsizetrends(unittest.TestCase):
         Service.execute = unittest.mock.MagicMock(return_value={"values": [["foo"], ["bar"]]})
         assert {"populated": False, "number": 3} == report_size_trends.get_current_row()
 
-    # @unittest.skip("")
     def test_create_row(self):
         spreadsheet_id = "test_spreadsheet_id"
         sheet_name = "test_sheet_name"
@@ -275,7 +267,6 @@ class TestReportsizetrends(unittest.TestCase):
                                                body={"values": json.loads(shared_data_columns_data)})
         Service.execute.assert_called_once()
 
-    # @unittest.skip("")
     def test_write_memory_usage_data(self):
         spreadsheet_id = "test_spreadsheet_id"
         sheet_name = "test_sheet_name"


### PR DESCRIPTION
It makes sense to standardize on a single unit testing framework for all of Arduino's Python code. Since [pytest](https://docs.pytest.org/en/latest/) is already in use in other Arduino projects, that's the one to use here as well.