### PR TITLE
libraries/spell-check: add CI workflow for linting of script

### DIFF
--- a/.github/workflows/libraries_spell-check.yml
+++ b/.github/workflows/libraries_spell-check.yml
@@ -23,3 +23,16 @@ jobs:
         with:
           path: "libraries/spell-check"
 
+  shfmt:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check shell script formatting
+        # https://github.com/mvdan/sh
+        run: docker run --volume "$GITHUB_WORKSPACE/libraries/spell-check":/mnt --workdir /mnt mvdan/shfmt:latest -w .
+
+      - name: Formatting diff
+        run: git diff --color --exit-code

--- a/.github/workflows/libraries_spell-check.yml
+++ b/.github/workflows/libraries_spell-check.yml
@@ -1,0 +1,25 @@
+name: libraries/spell-check workflow
+
+on:
+  push:
+    paths:
+      - ".github/workflows/libraries_spell-check.yml"
+      - "libraries/spell-check/**.sh"
+  pull_request:
+    paths:
+      - ".github/workflows/libraries_spell-check.yml"
+      - "libraries/spell-check/**.sh"
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: ShellCheck 
+        uses: azohra/shell-linter@v0.3.0
+        with:
+          path: "libraries/spell-check"
+

--- a/libraries/spell-check/.editorconfig
+++ b/libraries/spell-check/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.sh]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/libraries/spell-check/entrypoint.sh
+++ b/libraries/spell-check/entrypoint.sh
@@ -2,10 +2,10 @@
 
 readonly IGNORE_WORDS_LIST="$1"
 
-CODE_SPELL_ARGS=(--skip=.git)
+CODE_SPELL_ARGS=("--skip=.git")
 
 if test -f "$IGNORE_WORDS_LIST"; then
-  CODE_SPELL_ARGS=("${CODE_SPELL_ARGS[@]}" --ignore-words="${IGNORE_WORDS_LIST}")
+  CODE_SPELL_ARGS=("${CODE_SPELL_ARGS[@]}" "--ignore-words=${IGNORE_WORDS_LIST}")
 fi
 
 codespell "${CODE_SPELL_ARGS[@]}" .


### PR DESCRIPTION
- Use [ShellCheck](https://github.com/koalaman/shellcheck) (via [azohra/shell-linter](https://github.com/azohra/shell-linter)) for static analysis.
- Use [shfmt](https://github.com/mvdan/sh) for formatting check.