### PR TITLE
libraries/spell-check: Add tests

### DIFF
--- a/.github/workflows/libraries_spell-check.yml
+++ b/.github/workflows/libraries_spell-check.yml
@@ -5,12 +5,38 @@ on:
     paths:
       - ".github/workflows/libraries_spell-check.yml"
       - "libraries/spell-check/**.sh"
+      - "libraries/spell-check/test/**"
   pull_request:
     paths:
       - ".github/workflows/libraries_spell-check.yml"
       - "libraries/spell-check/**.sh"
+      - "libraries/spell-check/test/**"
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.8.2'
+
+      - name: Run tests 
+        run: |
+          pip3 --quiet --quiet install codespell
+          git clone --quiet https://github.com/bats-core/bats-core.git
+          cd bats-core
+          git fetch --tags
+          # Checkout the latest tag
+          git checkout --quiet $(git describe --tags `git rev-list --tags --max-count=1`)
+          sudo ./install.sh "/usr/local" > /dev/null
+          cd "$GITHUB_WORKSPACE/libraries/spell-check"
+          bats "./test"
+
   shellcheck:
     runs-on: ubuntu-latest
 

--- a/libraries/spell-check/test/test.bats
+++ b/libraries/spell-check/test/test.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+# Tests using the Bats testing framework
+
+@test "Find misspelled words" {
+  # codespell's exit status is the number of misspelled words found
+  expectedExitStatus=4
+  run ./entrypoint.sh
+  echo "Exit status: $status | Expected: $expectedExitStatus"
+  [ $status -eq $expectedExitStatus ]
+}
+
+@test "Use ignore-words-list argument" {
+  expectedExitStatus=0
+  run ./entrypoint.sh "./test/testdata/codespell-ignore-words-list.txt"
+  echo "Exit status: $status | Expected: $expectedExitStatus"
+  [ $status -eq $expectedExitStatus ]
+}
+
+@test "Ignore .git" {
+  expectedExitStatus=4
+  mkdir ".git"
+  cp "./test/testdata/has-misspellings/has-misspellings.txt" "./.git"
+  run ./entrypoint.sh
+  rm  --recursive "./.git"
+  echo "Exit status: $status | Expected: $expectedExitStatus"
+  [ $status -eq $expectedExitStatus ]
+}

--- a/libraries/spell-check/test/testdata/codespell-ignore-words-list.txt
+++ b/libraries/spell-check/test/testdata/codespell-ignore-words-list.txt
@@ -1,0 +1,2 @@
+dont
+wont

--- a/libraries/spell-check/test/testdata/has-misspellings/has-misspellings.txt
+++ b/libraries/spell-check/test/testdata/has-misspellings/has-misspellings.txt
@@ -1,0 +1,2 @@
+dont
+wont

--- a/libraries/spell-check/test/testdata/no-misspellings/no-misspellings.txt
+++ b/libraries/spell-check/test/testdata/no-misspellings/no-misspellings.txt
@@ -1,0 +1,2 @@
+don't
+won't


### PR DESCRIPTION
Add tests to quickly verify the action is working correctly using the [Bats testing framework](https://github.com/bats-core/bats-core).

The tests will run during the CI build on every change to the relevant files under `libraries/spell-check` or the workflow file itself.