### PR TITLE
Only run workflows when relevant files are modified

### DIFF
--- a/.github/workflows/libraries_compile-examples.yml
+++ b/.github/workflows/libraries_compile-examples.yml
@@ -1,6 +1,15 @@
 name: libraries/compile-examples workflow
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/libraries_compile-examples.yml'
+      - 'libraries/compile-examples/**'
+
+  push:
+    paths:
+      - '.github/workflows/libraries_compile-examples.yml'
+      - 'libraries/compile-examples/**'
 
 jobs:
   test:

--- a/.github/workflows/libraries_report-size-deltas.yml
+++ b/.github/workflows/libraries_report-size-deltas.yml
@@ -1,6 +1,15 @@
 name: libraries/report-size-deltas workflow
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/libraries_report-size-deltas.yml'
+      - 'libraries/report-size-deltas/**'
+
+  push:
+    paths:
+      - '.github/workflows/libraries_report-size-deltas.yml'
+      - 'libraries/report-size-deltas/**'
 
 jobs:
   test:

--- a/.github/workflows/setup-taskflile.yml
+++ b/.github/workflows/setup-taskflile.yml
@@ -1,6 +1,15 @@
 name: setup-taskfile workflow
 
-on: [push]
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/setup-taskflile.yml'
+      - 'setup-taskfile/**'
+
+  push:
+    paths:
+      - '.github/workflows/setup-taskflile.yml'
+      - 'setup-taskfile/**'
 
 jobs:
   test:


### PR DESCRIPTION
Running the workflow is only necessary when files under the action's folder or its workflow configuration itself are modified. For any other changes, the workflow run only slows down the CI results.

Reference:
https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths