### PR TITLE
Add --config option to flake8 command in CI workflows

### DIFF
--- a/.github/workflows/libraries_compile-examples.yml
+++ b/.github/workflows/libraries_compile-examples.yml
@@ -34,8 +34,8 @@ jobs:
         run: |
           pip install --quiet flake8
           pip install --quiet pep8-naming
-          flake8 --show-source "$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches"
-          flake8 --show-source "$GITHUB_WORKSPACE/libraries/compile-examples/reportsizetrends"
+          flake8 --config "$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches/.flake8" --show-source "$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches"
+          flake8 --config "$GITHUB_WORKSPACE/libraries/compile-examples/reportsizetrends/.flake8" --show-source "$GITHUB_WORKSPACE/libraries/compile-examples/reportsizetrends"
 
       - name: Run Python unit tests
         run: |

--- a/.github/workflows/libraries_report-size-deltas.yml
+++ b/.github/workflows/libraries_report-size-deltas.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install --quiet flake8
           pip install --quiet pep8-naming
-          flake8 --show-source "$GITHUB_WORKSPACE/libraries/report-size-deltas"
+          flake8 --config "$GITHUB_WORKSPACE/libraries/report-size-deltas/.flake8" --show-source "$GITHUB_WORKSPACE/libraries/report-size-deltas"
 
       - name: Run Python unit tests
         run: |


### PR DESCRIPTION
Before the latest release of flake8, the configuration file was automatically loaded based on the target path, but that is no longer supported as of the 3.8.0 release:
https://gitlab.com/pycqa/flake8/-/merge_requests/363