### PR TITLE
Add spell-check GitHub Actions workflow

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,17 @@
+name: Spell Check
+
+on: [push, pull_request]
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: ./libraries/spell-check
+        with:
+          ignore-words-list: etc/codespell-ignore-words-list.txt
+          skip-paths: ./libraries/spell-check/test/testdata,./setup-taskfile/node_modules,./setup-taskfile/package-lock.json

--- a/etc/codespell-ignore-words-list.txt
+++ b/etc/codespell-ignore-words-list.txt
@@ -1,0 +1,2 @@
+afterall
+clude

--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -288,7 +288,7 @@ class CompileSketches:
         """Return the appropriate name value for a repository dependency
 
         Keyword arguments:
-        dependency -- dictionary defining the Library/Board Manger dependency
+        dependency -- dictionary defining the Library/Board Manager dependency
         """
         name = dependency[self.dependency_name_key]
         if self.dependency_version_key in dependency:


### PR DESCRIPTION
The repository will be checked for commonly misspelled words on every pull request and push.

In the event of false positives, add the word you wish the check to ignore to `etc/codespell-ignore-words-list.txt`. Always use lowercase, as the ignore words list is case-sensitive and the list of commonly misspelled words is in lowercase.