### PR TITLE
libraries/compile-examples: allow installation of arbitrary platform dependencies

### DIFF
--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -16,6 +16,20 @@ For 3rd party boards, also specify the Boards Manager URL:
   fqbn: '"sandeepmistry:nRF5:Generic_nRF52832" "https://sandeepmistry.github.io/arduino-nRF5/package_nRF5_boards_index.json"'
 ```
 
+### `platforms`
+
+YAML-format list of platform dependencies to install.
+
+Default `""`. If no `platforms` input is provided, the board's dependency will be automatically determined from the `fqbn` input and the latest version of that platform will be installed via Board Manager.
+
+#### Sources:
+
+##### Board Manager
+
+Keys:
+- `name` - platform name in the form of `VENDOR:ARCHITECTURE`.
+- `version` - version of the platform to install. Default is the latest version.
+
 ### `libraries`
 
 YAML-format list of library dependencies to install.

--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -22,6 +22,17 @@ YAML-format list of platform dependencies to install.
 
 Default `""`. If no `platforms` input is provided, the board's dependency will be automatically determined from the `fqbn` input and the latest version of that platform will be installed via Board Manager.
 
+If a platform dependency from a non-Board Manager source of the same name as another Board Manager source platform dependency is defined, they will both be installed, with the non-Board Manager dependency overwriting the Board Manager platform installation. This permits testing against a non-release version of a platform while using Board Manager to install the platform's tools dependencies. 
+Example:
+```yaml
+platforms: |
+  # Install the latest release of Arduino SAMD Boards and its toolchain via Board Manager
+  - name: "arduino:samd"
+  # Install the platform from the root of the repository, replacing the BM installed platform
+  - source-path: "."
+    name: "arduino:samd"
+```
+
 #### Sources:
 
 ##### Board Manager
@@ -29,6 +40,12 @@ Default `""`. If no `platforms` input is provided, the board's dependency will b
 Keys:
 - `name` - platform name in the form of `VENDOR:ARCHITECTURE`.
 - `version` - version of the platform to install. Default is the latest version.
+
+##### Local path
+
+Keys:
+- `source-path` - path to install as a platform. Relative paths are assumed to be relative to the root of the repository.
+- `name` - platform name in the form of `VENDOR:ARCHITECTURE`.
 
 ### `libraries`
 

--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -50,7 +50,7 @@ Keys:
 
 Keys:
 - `source-url` - download URL for the archive (e.g., `https://github.com/arduino-libraries/Servo/archive/master.zip`).
-- `source-path` - path to install as a library. Paths are relative to the root folder of the archive. If the archive doesn't have a root folder, use `..` as `source-path` to install from the archive root. The default is to install from the root folder of the archive.
+- `source-path` - path to install as a library. Paths are relative to the root folder of the archive, or the root of the archive if it has no root folder. The default is to install from the root folder of the archive.
 - `destination-name` - folder name to install the library to. By default, the folder will be named according to the source archive or subfolder name.
 
 ### `sketch-paths`

--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -47,6 +47,14 @@ Keys:
 - `source-path` - path to install as a platform. Relative paths are assumed to be relative to the root of the repository.
 - `name` - platform name in the form of `VENDOR:ARCHITECTURE`.
 
+##### Repository
+
+Keys:
+- `source-url` - URL to clone the repository from. It must start with `git://` or end with `.git`.
+- `version` - [Git ref](https://git-scm.com/book/en/v2/Git-Internals-Git-References) of the repository to checkout. The special version name `latest` will cause the latest tag to be used. By default, the repository will be checked out to the tip of the default branch.
+- `source-path` - path to install as a library. Paths are relative to the root of the repository. The default is to install from the root of the repository.
+- `name` - platform name in the form of `VENDOR:ARCHITECTURE`.
+
 ### `libraries`
 
 YAML-format list of library dependencies to install.

--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -55,6 +55,13 @@ Keys:
 - `source-path` - path to install as a library. Paths are relative to the root of the repository. The default is to install from the root of the repository.
 - `name` - platform name in the form of `VENDOR:ARCHITECTURE`.
 
+##### Archive download
+
+Keys:
+- `source-url` - download URL for the archive (e.g., `https://github.com/arduino/ArduinoCore-avr/archive/master.zip`).
+- `source-path` - path to install as a library. Paths are relative to the root folder of the archive, or the root of the archive if it has no root folder. The default is to install from the root folder of the archive.
+- `name` - platform name in the form of `VENDOR:ARCHITECTURE`.
+
 ### `libraries`
 
 YAML-format list of library dependencies to install.

--- a/libraries/compile-examples/action.yml
+++ b/libraries/compile-examples/action.yml
@@ -10,6 +10,9 @@ inputs:
   libraries:
     description: 'YAML-format list of library dependencies to install'
     default: '- source-path: ./'
+  platforms:
+    description: 'YAML-format list of platform dependencies to install'
+    default: ''
   sketch-paths:
     description: 'List of paths containing sketches to compile.'
     default: 'examples'

--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -48,7 +48,7 @@ class CompileSketches:
     cli_version -- version of the Arduino CLI to use
     fqbn_arg -- fully qualified board name of the board to compile for. Space separated list with Boards Manager URL if
                 needed
-    libraries -- space-separated list of libraries to install
+    libraries -- YAML-format or space-separated list of libraries to install
     sketch_paths -- space-separated list of paths containing sketches to compile. These paths will be searched
                     recursively for sketches.
     verbose -- set to "true" for verbose output ("true", "false")
@@ -242,7 +242,7 @@ class CompileSketches:
                         # All other URLs are assumed to be downloads
                         sorted_dependencies.download.append(dependency)
                 elif self.dependency_source_path_key in dependency:
-                    # Libraries with source-path and no source-url are assumed to be paths
+                    # Dependencies with source-path and no source-url are assumed to be paths
                     sorted_dependencies.path.append(dependency)
                 else:
                     # All others are Library/Board Manager names
@@ -285,7 +285,9 @@ class CompileSketches:
         self.run_arduino_cli_command(command=core_install_command, enable_output=self.get_run_command_output_level())
 
     def get_manager_dependency_name(self, dependency):
-        """Return the appropriate name value for a repository dependency
+        """Return the appropriate name value for a manager dependency. This allows the NAME@VERSION syntax to be used
+        with the special "latest" ref for the sake of consistency (though the documented approach is to use the version
+        key to specify version.
 
         Keyword arguments:
         dependency -- dictionary defining the Library/Board Manger dependency

--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -237,6 +237,9 @@ class CompileSketches:
         if len(platform_list.repository) > 0:
             self.install_platforms_from_repository(platform_list=platform_list.repository)
 
+        if len(platform_list.download) > 0:
+            self.install_platforms_from_download(platform_list=platform_list.download)
+
     def get_fqbn_platform_dependency(self):
         """Return the platform dependency definition automatically generated from the FQBN."""
         # Extract the platform name from the FQBN (e.g., arduino:avr:uno => arduino:avr)
@@ -563,6 +566,26 @@ class CompileSketches:
 
             # checkout ref
             cloned_repository.git.checkout(git_ref)
+
+    def install_platforms_from_download(self, platform_list):
+        """Install libraries by downloading them
+
+        Keyword arguments:
+        platform_list -- list of dictionaries defining the dependencies
+        """
+        for platform in platform_list:
+            self.verbose_print("Installing platform from download URL:", platform[self.dependency_source_url_key])
+            if self.dependency_source_path_key in platform:
+                source_path = platform[self.dependency_source_path_key]
+            else:
+                source_path = "."
+
+            destination_path = self.get_platform_installation_path(platform=platform)
+
+            install_from_download(url=platform[self.dependency_source_url_key],
+                                  source_path=source_path,
+                                  destination_parent_path=destination_path.base,
+                                  destination_name=destination_path.platform)
 
     def install_libraries(self):
         """Install Arduino libraries."""

--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -234,6 +234,9 @@ class CompileSketches:
         if len(platform_list.path) > 0:
             self.install_platforms_from_path(platform_list=platform_list.path)
 
+        if len(platform_list.repository) > 0:
+            self.install_platforms_from_repository(platform_list=platform_list.repository)
+
     def get_fqbn_platform_dependency(self):
         """Return the platform dependency definition automatically generated from the FQBN."""
         # Extract the platform name from the FQBN (e.g., arduino:avr:uno => arduino:avr)
@@ -465,6 +468,30 @@ class CompileSketches:
                 break
 
         return platform_installation_path
+
+    def install_platforms_from_repository(self, platform_list):
+        """Install libraries by cloning Git repositories
+
+        Keyword arguments:
+        platform_list -- list of dictionaries defining the dependencies
+        """
+        for platform in platform_list:
+            self.verbose_print("Installing platform from repository:", platform[self.dependency_source_url_key])
+
+            git_ref = self.get_repository_dependency_ref(dependency=platform)
+
+            if self.dependency_source_path_key in platform:
+                source_path = platform[self.dependency_source_path_key]
+            else:
+                source_path = "."
+
+            destination_path = self.get_platform_installation_path(platform=platform)
+
+            self.install_from_repository(url=platform[self.dependency_source_url_key],
+                                         git_ref=git_ref,
+                                         source_path=source_path,
+                                         destination_parent_path=destination_path.base,
+                                         destination_name=destination_path.platform)
 
     def get_repository_dependency_ref(self, dependency):
         """Return the appropriate git ref value for a repository dependency

--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -539,8 +539,6 @@ class CompileSketches:
 
     def install_libraries(self):
         """Install Arduino libraries."""
-        self.libraries_path.mkdir(parents=True, exist_ok=True)
-
         libraries = yaml.load(stream="", Loader=yaml.SafeLoader)
         try:
             libraries = yaml.load(stream=self.libraries, Loader=yaml.SafeLoader)
@@ -610,6 +608,9 @@ class CompileSketches:
             else:
                 # Use the existing folder name
                 destination_name = source_path.name
+
+            # Create the parent path if it doesn't exist already
+            self.libraries_path.mkdir(parents=True, exist_ok=True)
 
             # Install the library by creating a symlink in the sketchbook
             library_symlink_path = self.libraries_path.joinpath(destination_name)

--- a/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
+++ b/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
@@ -21,6 +21,7 @@ test_data_path = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__)), "
 def get_compilesketches_object(
     cli_version=unittest.mock.sentinel.cli_version,
     fqbn_arg="foo fqbn_arg",
+    platforms="- name: FooVendor:BarArchitecture",
     libraries="foo libraries",
     sketch_paths="foo sketch_paths",
     verbose="false",
@@ -35,6 +36,7 @@ def get_compilesketches_object(
 ):
     return compilesketches.CompileSketches(cli_version=cli_version,
                                            fqbn_arg=fqbn_arg,
+                                           platforms=platforms,
                                            libraries=libraries,
                                            sketch_paths=sketch_paths,
                                            verbose=verbose,
@@ -81,6 +83,7 @@ def test_directories_are_same():
 def test_main(monkeypatch, mocker):
     cli_version = "1.0.0"
     fqbn_arg = "foo:bar:baz"
+    platforms = "- name: FooVendor:BarArchitecture"
     libraries = "foo libraries"
     sketch_paths = "foo/Sketch bar/OtherSketch"
     verbose = "true"
@@ -99,6 +102,7 @@ def test_main(monkeypatch, mocker):
 
     monkeypatch.setenv("INPUT_CLI-VERSION", cli_version)
     monkeypatch.setenv("INPUT_FQBN", fqbn_arg)
+    monkeypatch.setenv("INPUT_PLATFORMS", platforms)
     monkeypatch.setenv("INPUT_LIBRARIES", libraries)
     monkeypatch.setenv("INPUT_SKETCH-PATHS", sketch_paths)
     monkeypatch.setenv("INPUT_GITHUB-TOKEN", github_token)
@@ -119,6 +123,7 @@ def test_main(monkeypatch, mocker):
     compilesketches.CompileSketches.assert_called_once_with(
         cli_version=cli_version,
         fqbn_arg=fqbn_arg,
+        platforms=platforms,
         libraries=libraries,
         sketch_paths=sketch_paths,
         verbose=verbose,
@@ -138,6 +143,7 @@ def test_compilesketches():
     expected_fqbn = "foo:bar:baz"
     expected_additional_url = "https://example.com/package_foo_index.json"
     cli_version = unittest.mock.sentinel.cli_version
+    platforms = unittest.mock.sentinel.platforms
     libraries = unittest.mock.sentinel.libraries
     sketch_paths = "examples/FooSketchPath examples/BarSketchPath"
     expected_sketch_paths_list = [pathlib.PurePath("examples/FooSketchPath"),
@@ -155,6 +161,7 @@ def test_compilesketches():
     compile_sketches = compilesketches.CompileSketches(
         cli_version=cli_version,
         fqbn_arg="\'\"" + expected_fqbn + "\" \"" + expected_additional_url + "\"\'",
+        platforms=platforms,
         libraries=libraries,
         sketch_paths=sketch_paths,
         verbose=verbose,
@@ -171,6 +178,7 @@ def test_compilesketches():
     assert compile_sketches.cli_version == cli_version
     assert compile_sketches.fqbn == expected_fqbn
     assert compile_sketches.additional_url == expected_additional_url
+    assert compile_sketches.platforms == platforms
     assert compile_sketches.libraries == libraries
     assert compile_sketches.sketch_paths == expected_sketch_paths_list
     assert compile_sketches.verbose is False
@@ -303,26 +311,79 @@ def test_install_arduino_cli(mocker):
         destination_parent_path=arduino_cli_installation_path)
 
     assert os.environ["ARDUINO_DIRECTORIES_USER"] == str(arduino_cli_user_directory_path)
+@pytest.mark.parametrize("platforms", ["", "foo"])
+def test_install_platforms(mocker, platforms):
+    fqbn_platform_dependency = unittest.mock.sentinel.fqbn_platform_dependency
+    dependency_list_manager = [unittest.mock.sentinel.manager]
+    dependency_list_path = [unittest.mock.sentinel.path]
+    dependency_list_repository = [unittest.mock.sentinel.repository]
+    dependency_list_download = [unittest.mock.sentinel.download]
 
+    dependency_list = compilesketches.CompileSketches.Dependencies()
+    dependency_list.manager = dependency_list_manager
+    dependency_list.path = dependency_list_path
+    dependency_list.repository = dependency_list_repository
+    dependency_list.download = dependency_list_download
 
-@pytest.mark.parametrize(
-    "fqbn_arg, expected_platform, expected_additional_url_list",
-    [("arduino:avr:uno", "arduino:avr", []),
-     ('\'"foo bar:baz:asdf" "https://example.com/platform_foo_index.json"\'', "foo bar:baz",
-      ["https://example.com/platform_foo_index.json"])]
-)
-def test_install_platforms(mocker, fqbn_arg, expected_platform, expected_additional_url_list):
-    compile_sketches = get_compilesketches_object(fqbn_arg=fqbn_arg)
+    compile_sketches = get_compilesketches_object(platforms=platforms)
 
+    mocker.patch("compilesketches.CompileSketches.get_fqbn_platform_dependency",
+                 autospec=True,
+                 return_value=fqbn_platform_dependency)
+    mocker.patch("compilesketches.CompileSketches.sort_dependency_list",
+                 autospec=True,
+                 return_value=dependency_list)
     mocker.patch("compilesketches.CompileSketches.install_platforms_from_board_manager", autospec=True)
+    mocker.patch("compilesketches.CompileSketches.install_platforms_from_path", autospec=True)
+    mocker.patch("compilesketches.CompileSketches.install_platforms_from_repository", autospec=True)
+    mocker.patch("compilesketches.CompileSketches.install_platforms_from_download", autospec=True)
 
     compile_sketches.install_platforms()
 
-    compile_sketches.install_platforms_from_board_manager.assert_called_once_with(
-        compile_sketches,
-        platform_list=[expected_platform],
-        additional_url_list=expected_additional_url_list
-    )
+    if platforms == "":
+        compile_sketches.install_platforms_from_board_manager.assert_called_once_with(
+            compile_sketches,
+            platform_list=[fqbn_platform_dependency]
+        )
+        compile_sketches.install_platforms_from_path.assert_not_called()
+        compile_sketches.install_platforms_from_repository.assert_not_called()
+        compile_sketches.install_platforms_from_download.assert_not_called()
+    else:
+        compile_sketches.install_platforms_from_board_manager.assert_called_once_with(
+            compile_sketches,
+            platform_list=dependency_list_manager
+        )
+        compile_sketches.install_platforms_from_path.assert_called_once_with(
+            compile_sketches,
+            platform_list=dependency_list_path
+        )
+        compile_sketches.install_platforms_from_repository.assert_called_once_with(
+            compile_sketches,
+            platform_list=dependency_list_repository
+        )
+        compile_sketches.install_platforms_from_download.assert_called_once_with(
+            compile_sketches,
+            platform_list=dependency_list_download
+        )
+
+
+@pytest.mark.parametrize(
+    "fqbn_arg, expected_platform, expected_additional_url",
+    [("arduino:avr:uno", "arduino:avr", None),
+     # FQBN with space, additional Board Manager URL
+     ('\'"foo bar:baz:asdf" "https://example.com/platform_foo_index.json"\'', "foo bar:baz",
+      "https://example.com/platform_foo_index.json")]
+)
+def test_get_fqbn_platform_dependency(fqbn_arg, expected_platform, expected_additional_url):
+    compile_sketches = get_compilesketches_object(fqbn_arg=fqbn_arg)
+
+    fqbn_platform_dependency = compile_sketches.get_fqbn_platform_dependency()
+
+    assert fqbn_platform_dependency[compilesketches.CompileSketches.dependency_name_key] == expected_platform
+    if expected_additional_url is not None:
+        assert fqbn_platform_dependency[compilesketches.CompileSketches.dependency_source_url_key] == (
+            expected_additional_url
+        )
 
 
 @pytest.mark.parametrize(
@@ -336,6 +397,9 @@ def test_install_platforms(mocker, fqbn_arg, expected_platform, expected_additio
      ([{compilesketches.CompileSketches.dependency_source_url_key: "https://example.com/foo/bar"}], ["download"]),
      ([{compilesketches.CompileSketches.dependency_source_path_key: "foo/bar"}], ["path"]),
      ([{compilesketches.CompileSketches.dependency_name_key: "FooBar"}], ["manager"]),
+     ([{compilesketches.CompileSketches.dependency_name_key: "FooBar",
+        compilesketches.CompileSketches.dependency_source_url_key: "https://example.com/package_foo_index.json"}],
+      ["manager"]),
      ([{compilesketches.CompileSketches.dependency_source_url_key: "git://example.com/foo/bar"},
        {compilesketches.CompileSketches.dependency_source_url_key: "https://example.com/foo/bar"},
        {compilesketches.CompileSketches.dependency_source_path_key: "foo/bar"},
@@ -354,12 +418,29 @@ def test_sort_dependency_list(monkeypatch, dependency_list, expected_dependency_
                                      expected_dependency_type)
 
 
-@pytest.mark.parametrize("additional_url_list",
-                         [["https://example.com/package_foo_index.json", "https://example.com/package_bar_index.json"],
-                          []])
-def test_install_platforms_from_board_manager(mocker, additional_url_list):
+@pytest.mark.parametrize(
+    "platform_list, expected_core_update_index_command_list, expected_core_install_command_list",
+    [(
+        [{compilesketches.CompileSketches.dependency_name_key: "Foo"},
+         {compilesketches.CompileSketches.dependency_name_key: "Bar"}],
+        [["core", "update-index"], ["core", "update-index"]],
+        [["core", "install", "Foo"], ["core", "install", "Bar"]]
+    ), (
+        # Additional Board Manager URL
+        [{compilesketches.CompileSketches.dependency_name_key: "Foo",
+          compilesketches.CompileSketches.dependency_source_url_key: "https://example.com/package_foo_index.json"},
+         {compilesketches.CompileSketches.dependency_name_key: "Bar",
+          compilesketches.CompileSketches.dependency_source_url_key: "https://example.com/package_bar_index.json"}],
+        [["core", "update-index", "--additional-urls", "https://example.com/package_foo_index.json"],
+         ["core", "update-index", "--additional-urls", "https://example.com/package_bar_index.json"]],
+        [["core", "install", "--additional-urls", "https://example.com/package_foo_index.json", "Foo"],
+         ["core", "install", "--additional-urls", "https://example.com/package_bar_index.json", "Bar"]]
+    )])
+def test_install_platforms_from_board_manager(mocker,
+                                              platform_list,
+                                              expected_core_update_index_command_list,
+                                              expected_core_install_command_list):
     run_command_output_level = unittest.mock.sentinel.run_command_output_level
-    platform_list = [unittest.mock.sentinel.platform1, unittest.mock.sentinel.platform2]
 
     compile_sketches = get_compilesketches_object()
 
@@ -367,19 +448,22 @@ def test_install_platforms_from_board_manager(mocker, additional_url_list):
                  return_value=run_command_output_level)
     mocker.patch("compilesketches.CompileSketches.run_arduino_cli_command", autospec=True)
 
-    compile_sketches.install_platforms_from_board_manager(platform_list=platform_list,
-                                                          additional_url_list=additional_url_list)
+    compile_sketches.install_platforms_from_board_manager(platform_list=platform_list)
 
-    core_update_command = ["core", "update-index"]
-    core_install_command = ["core", "install"]
-    core_install_command.extend(platform_list)
-    if len(additional_url_list) > 0:
-        additional_urls_option = ["--additional-urls", ",".join(additional_url_list)]
-        core_update_command.extend(additional_urls_option)
-        core_install_command.extend(additional_urls_option)
-    run_arduino_cli_command_calls = [
-        unittest.mock.call(compile_sketches, command=core_update_command, enable_output=run_command_output_level),
-        unittest.mock.call(compile_sketches, command=core_install_command, enable_output=run_command_output_level)]
+    run_arduino_cli_command_calls = []
+    for expected_core_update_index_command, expected_core_install_command in zip(
+        expected_core_update_index_command_list,
+        expected_core_install_command_list
+    ):
+        run_arduino_cli_command_calls.extend([
+            unittest.mock.call(compile_sketches,
+                               command=expected_core_update_index_command,
+                               enable_output=run_command_output_level),
+            unittest.mock.call(compile_sketches,
+                               command=expected_core_install_command,
+                               enable_output=run_command_output_level)
+        ])
+
     compile_sketches.run_arduino_cli_command.assert_has_calls(calls=run_arduino_cli_command_calls)
 
 


### PR DESCRIPTION
Arbitrary platform dependencies may now be specified via the newly added `platforms` input. This input uses the same YAML-list format and key names as the `libraries` input.

Backwards compatibility is provided by retaining the same behavior of automatically installing the board's platform dependency, as inferred from the fqbn input. The additional Board Manager URL may still be passed via the fqbn input, if desired.


---
### Platform dependency sources:
- Board Manager
- Local path
- Clone repository
- Archive download

---
### Use cases
#### Compilation testing of platforms
The platform under test may now be installed from the local path of the library.

The easiest way to install the platform's tools dependencies is via Board Manager. If the platform from the local path was also installed via Board Manager (as identified by them having the same name value), the Board Manager platform will be replaced by the one from the local path.

#### Testing against a non-release version of a platform
It may be desirable to test against the development version of the platform to catch incompatibilities in advance of the release.

#### Platform dependencies that have a dependency on another platform
Some platforms referenced tools, cores, or variants from another platform, which must also be installed. It was not previously possible to use these platforms with the action.

#### Testing against a specific platform version
Previously, the latest release of the platform was always used.

#### Use of platform dependencies that don't have Board Manager installation support

---
#### Demonstration workflow using all sources:
https://github.com/per1234/actions/blob/platforms-input-demo/.github/workflows/compile-examples.yml
```yaml
      matrix:
        fqbn: [
          "arduino:samd:mkrzero",
          "esp8266:esp8266:huzzah",
          "attiny:avr:ATtinyX5",
          "foo:avr:bar",
          "arduino:avr:funo",
          "ATTinyCore:avr:attinyx4",
          "MicroCore:avr:attiny13",
          "MiniCore:avr:328",
          "breadboard:avr:atmega328bb"
        ]

        include:
          - fqbn: "arduino:samd:mkrzero"
            platforms: |
              # Install 1.8.6 release from Board Manager
              - name: "arduino:samd"
                version: "1.8.6"

          - fqbn: "esp8266:esp8266:huzzah"
            platforms: |
              # From BM with additional URL, latest release
              - name: "esp8266:esp8266"
                source-url: "https://arduino.esp8266.com/stable/package_esp8266com_index.json"

          - fqbn: "attiny:avr:ATtinyX5"
            platforms: |
              # This platform provides the referenced core for the attiny:avr platform
              - name: 'arduino:avr'
              - name: "attiny:avr"
                source-url: 'https://raw.githubusercontent.com/damellis/attiny/ide-1.6.x-boards-manager/package_damellis_attiny_index.json'

          - fqbn: "foo:avr:bar"
            platforms: |
              # This platform provides referenced tools dependencies, core, and variants for the foo:avr platform
              - name: "arduino:avr"
              # Install the repository from local path as a platform named foo:avr
              - source-path: "./"
                name: "foo:avr"

          - fqbn: "arduino:avr:funo"
            platforms: |
              # This platform provides tools dependencies for the version of the arduino:avr platform installed from the local avr path
              - name: "arduino:avr"
              # Install from local path subfolder, overwriting the arduino:avr platform previously installed via BM
              - source-path: "avr"
                name: "arduino:avr"

          - fqbn: "ATTinyCore:avr:attinyx4"
            platforms: |
              # This platform provides referenced tools dependencies for the ATTinyCore:avr platform
              - name: 'arduino:avr'
              # Install by cloning Git repo, checked out to the tip of the default branch, installed from the root of the repository
              - source-url: "https://github.com/SpenceKonde/ATTinyCore.git"
                source-path: 'avr'
                name: "ATTinyCore:avr"

          - fqbn: "MicroCore:avr:attiny13"
            platforms: |
              # This platform provides referenced tools dependencies for the MicroCore:avr platform
              - name: 'arduino:avr'
              # Repo checked out to specific Git ref, installed from avr subfolder of repo
              - source-url: 'https://github.com/MCUdude/MicroCore.git/'
                version: 'v1.0.4'
                source-path: 'avr'
                name: 'MicroCore:avr'

          - fqbn: "MiniCore:avr:328"
            platforms: |
              # This platform provides referenced tools dependencies for the MiniCore:avr platform
              - name: 'arduino:avr'
              # Checked out to the latest tag
              - source-url: 'git://github.com/MCUdude/MiniCore'
                version: 'latest'
                source-path: 'avr'
                name: 'MiniCore:avr'

          - fqbn: "breadboard:avr:atmega328bb"
            platforms: |
              # This platform provides referenced tools dependencies, core, and variant for the breadboard:avr platform
              - name: 'arduino:avr'
              # Install from download
              - source-url: 'https://www.arduino.cc/en/uploads/Tutorial/breadboard-1-6-x.zip'
                source-path: 'avr'
                name: 'breadboard:avr'
```
Workflow run log:
https://github.com/per1234/actions/runs/676261801?check_suite_focus=true

---
#### Platform testing demonstration
The action now makes compilation testing of platforms easy.

Workflow for testing Arduino megaAVR Boards:
https://github.com/per1234/ArduinoCore-megaavr/blob/compilation-test/.github/workflows/compile-examples.yml

Workflow run log:
https://github.com/per1234/ArduinoCore-megaavr/runs/676253562?check_suite_focus=true

---
#### Backwards compatibility demonstration

Existing ArduinoIoTCloud workflow run with this version of the action:
https://github.com/per1234/ArduinoIoTCloud/actions/runs/105123911