### PR TITLE
libraries/spell-check: make miscellaneous improvements to the documentation

### DIFF
--- a/libraries/spell-check/README.md
+++ b/libraries/spell-check/README.md
@@ -1,6 +1,6 @@
 # libraries/spell-check action
 
-Runs [codespell](https://github.com/codespell-project/codespell) on library source code and examples contained in the library.
+Uses [codespell](https://github.com/codespell-project/codespell) to check files for commonly misspelled words.
 
 ## Inputs
 

--- a/libraries/spell-check/README.md
+++ b/libraries/spell-check/README.md
@@ -1,6 +1,6 @@
 # libraries/spell-check action
 
-Runs codespell on library source code and examples contained in the library.
+Runs [codespell](https://github.com/codespell-project/codespell) on library source code and examples contained in the library.
 
 ## Inputs
 

--- a/libraries/spell-check/action.yml
+++ b/libraries/spell-check/action.yml
@@ -1,5 +1,5 @@
-name: 'Arduino Libraries - Spell Check'
-description: 'Runs codespell on library source code and examples contained in the library'
+name: 'Spell Check'
+description: 'Uses codespell to check files for commonly misspelled words'
 inputs:
   ignore-words-list:
     description: 'File path of list of words to ignore'


### PR DESCRIPTION
### Add codespell link to readme
Since this action is only a thin wrapper around [codespell](https://github.com/codespell-project/codespell), it makes sense to add a link to give that excellent project even more recognition.

Users may also find additional information about how the action works in the codespell documentation.

### Remove mention of libraries from documentation

There is absolutely nothing about this action that is specific to libraries. It's just a general check for misspelled words that can be used for any project.