### PR TITLE
libraries/compile-examples: support sketch paths located outside the workspace

### DIFF
--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -22,7 +22,7 @@ YAML-format list of platform dependencies to install.
 
 Default `""`. If no `platforms` input is provided, the board's dependency will be automatically determined from the `fqbn` input and the latest version of that platform will be installed via Board Manager.
 
-If a platform dependency from a non-Board Manager source of the same name as another Board Manager source platform dependency is defined, they will both be installed, with the non-Board Manager dependency overwriting the Board Manager platform installation. This permits testing against a non-release version of a platform while using Board Manager to install the platform's tools dependencies. 
+If a platform dependency from a non-Board Manager source of the same name as another Board Manager source platform dependency is defined, they will both be installed, with the non-Board Manager dependency overwriting the Board Manager platform installation. This permits testing against a non-release version of a platform while using Board Manager to install the platform's tools dependencies.
 Example:
 ```yaml
 platforms: |
@@ -68,6 +68,8 @@ YAML-format list of library dependencies to install.
 
 Default `"- source-path: ./"`. This causes the repository to be installed as a library. If there are no library dependencies and you want to override the default, set the `libraries` input to an empty list (`- libraries: '-'`).
 
+Libraries are installed under the Arduino user folder at `~/Arduino/libraries`.
+
 Note: the original space-separated list format is also supported. When this syntax is used, the repository under test will always be installed as a library.
 
 #### Sources:
@@ -75,7 +77,7 @@ Note: the original space-separated list format is also supported. When this synt
 ##### Library Manager
 
 Keys:
-- `name` - name of the library.
+- `name` - name of the library, as defined in the `name` field of its [library.properties](https://arduino.github.io/arduino-cli/library-specification/#libraryproperties-file-format) metadata file. The library will be installed to a folder matching the name, but with any spaces replaced by `_`.
 - `version` - version of the library to install. Default is the latest version.
 
 ##### Local path

--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -626,7 +626,7 @@ class CompileSketches:
                 # If a name was specified, use it
                 destination_name = library[self.dependency_destination_name_key]
             elif (
-                source_path == pathlib.Path(os.environ["GITHUB_WORKSPACE"])
+                source_path == absolute_path(os.environ["GITHUB_WORKSPACE"])
             ):
                 # If source_path is the root of the workspace (i.e., repository root), name the folder according to the
                 # repository name, otherwise it will unexpectedly be "workspace"
@@ -1047,9 +1047,9 @@ def path_relative_to_workspace(path):
     Keyword arguments:
     path -- the path to make relative
     """
-    path = pathlib.Path(path)
+    path = absolute_path(path=path)
     try:
-        relative_path = path.relative_to(os.environ["GITHUB_WORKSPACE"])
+        relative_path = path.relative_to(absolute_path(path=os.environ["GITHUB_WORKSPACE"]))
     except ValueError:
         # Path is outside workspace, so just use the given path
         relative_path = path
@@ -1064,10 +1064,14 @@ def absolute_path(path):
     Keyword arguments:
     path -- the path to make absolute
     """
-    path = pathlib.Path(path)
+    # Make path into a pathlib.Path object, with ~ expanded
+    path = pathlib.Path(path).expanduser()
     if not path.is_absolute():
         # path is relative
         path = pathlib.Path(os.environ["GITHUB_WORKSPACE"], path)
+
+    # Resolve .. and symlinks to get a true absolute path
+    path = path.resolve()
 
     return path
 

--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -1047,8 +1047,14 @@ def path_relative_to_workspace(path):
     Keyword arguments:
     path -- the path to make relative
     """
-    path = pathlib.PurePath(path)
-    return path.relative_to(os.environ["GITHUB_WORKSPACE"])
+    path = pathlib.Path(path)
+    try:
+        relative_path = path.relative_to(os.environ["GITHUB_WORKSPACE"])
+    except ValueError:
+        # Path is outside workspace, so just use the given path
+        relative_path = path
+
+    return relative_path
 
 
 def absolute_path(path):

--- a/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
+++ b/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
@@ -1506,6 +1506,8 @@ def test_path_relative_to_workspace(monkeypatch):
     assert compilesketches.path_relative_to_workspace(path=pathlib.PurePath("/fooWorkspace", "baz")
                                                       ) == pathlib.PurePath("baz")
     assert compilesketches.path_relative_to_workspace(path="/fooWorkspace/baz") == pathlib.PurePath("baz")
+    # Test path outside workspace
+    assert compilesketches.path_relative_to_workspace(path="/bar/foo") == pathlib.PurePath("/bar/foo")
 
 
 @pytest.mark.parametrize("path, expected_absolute_path", [("/asdf", "/asdf"), ("asdf", "/fooWorkspace/asdf")])


### PR DESCRIPTION
The user may wish to run compilation tests on sketches bundled with installed library dependencies. These are installed to `/home/github/Arduino/libraries`, which is outside the working directory of the action's Docker container.

Use cases:
- Checking impact of changes on libraries that have the library under test as a dependency.
- Checking impact of changes to the platform under test on external libraries.

This required:
- Fixing a bug with the code used to provide user-friendly relative paths in log and report output that made it incompatible with paths outside the working directory provided by the user via the `sketch-paths` input.
- Adding support for `~` in input paths. This allows users to use the familiar universal default user directory (sketchbook) path location (`~/Arduino`) instead of needing to remember that `HOME` in the docker container is `/github/home`.
- Documenting that the libraries are installed under `~/Arduino/libraries`