### PR TITLE
Update Python version used in CI workflows and actions

### DIFF
--- a/.github/workflows/libraries_compile-examples.yml
+++ b/.github/workflows/libraries_compile-examples.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8.2'
+          python-version: '3.8.3'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/libraries_report-size-deltas.yml
+++ b/.github/workflows/libraries_report-size-deltas.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8.2'
+          python-version: '3.8.3'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/libraries_report-size-trends.yml
+++ b/.github/workflows/libraries_report-size-trends.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8.2'
+          python-version: '3.8.3'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/libraries_spell-check.yml
+++ b/.github/workflows/libraries_spell-check.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v1
-        with:
-          python-version: '3.8.2'
 
       - name: Run tests 
         run: |

--- a/libraries/compile-examples/Dockerfile
+++ b/libraries/compile-examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.2
+FROM python:3.8.3
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY compilesketches /compilesketches

--- a/libraries/report-size-deltas/Dockerfile
+++ b/libraries/report-size-deltas/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.2
+FROM python:3.8.3
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY reportsizedeltas.py /reportsizedeltas.py

--- a/libraries/report-size-trends/Dockerfile
+++ b/libraries/report-size-trends/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.2
+FROM python:3.8.3
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY reportsizetrends /reportsizetrends


### PR DESCRIPTION
The `actions/setup-python` action no longer offers the Python 3.8.2 that was pinned in the workflows. This will cause the runs of this repository's CI workflows to error.

For the actions that have a pinned Python version (`compile-examples`, `report-size-deltas`, `report-size-trends`), it makes sense to use the same Python version to run the action as we do to test it, so Python 3.8.3 is now pinned in their CI workflows and Dockerfiles instead of 3.8.2.

The `spell-check` action's Dockerfile just uses whatever version `apt-get install python3` provides, so it makes more sense to configure its CI workflow to just use the default version of Python provided by the `actions/setup-python` action.

---
NOTE: the `libraries/spell-check` workflow is expected to fail due to a release of codespell's changed dictionary breaking the tests. This is completely unrelated to the change in Python version and will be fixed by https://github.com/arduino/actions/pull/58.