### PR TITLE
libraries/spell-check: update test data to reflect changes to the codespell dictionary

### DIFF
--- a/libraries/spell-check/test/testdata/codespell-ignore-words-list.txt
+++ b/libraries/spell-check/test/testdata/codespell-ignore-words-list.txt
@@ -1,2 +1,2 @@
-dont
-wont
+abandonned
+ackward

--- a/libraries/spell-check/test/testdata/has-misspellings/has-misspellings1/has-misspellings.txt
+++ b/libraries/spell-check/test/testdata/has-misspellings/has-misspellings1/has-misspellings.txt
@@ -1,2 +1,2 @@
-dont
-wont
+abandonned
+ackward

--- a/libraries/spell-check/test/testdata/has-misspellings/has-misspellings2/has-misspellings.txt
+++ b/libraries/spell-check/test/testdata/has-misspellings/has-misspellings2/has-misspellings.txt
@@ -1,2 +1,2 @@
-dont
-wont
+abandonned
+ackward

--- a/libraries/spell-check/test/testdata/no-misspellings/no-misspellings.txt
+++ b/libraries/spell-check/test/testdata/no-misspellings/no-misspellings.txt
@@ -1,2 +1,2 @@
-don't
-won't
+abandoned
+awkward


### PR DESCRIPTION
"dont" was removed from codespell's commonly misspelled words dictionary in the release that happened a couple days ago (apparently it is used enough as a variable name to warrant being moved to the "code" dictionary, which we don't configure codespell to use). This word was previously used in the tests to trigger the action's misspelled word detection, so its removal broke the tests.

Although it was not necessary, I also switched from using "wont" in the test data as a misspelled word, since this is likely to suffer the same fate eventually (especially since it's a valid word and shouldn't have been in the dictionary to begin with).

---
NOTE: the `libraries/spell-check` workflow is expected to fail due to Python 3.8.2 no longer being available for installation by the `actions/setup-python` action. This is completely unrelated to the codespell release and will be fixed by https://github.com/arduino/actions/pull/57.