### PR TITLE
libraries/compile-examples: add support for .pde sketch extension

### DIFF
--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -1080,7 +1080,7 @@ def path_is_sketch(path):
     Keyword arguments:
     path -- path of to check for a sketch
     """
-    sketch_extensions = [".ino"]  # TODO: this is preparation for the addition of support for the .pde extension
+    sketch_extensions = [".ino", ".pde"]
 
     path = pathlib.Path(path)
 

--- a/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
+++ b/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
@@ -1065,9 +1065,13 @@ def test_path_is_sketch():
     assert compilesketches.path_is_sketch(
         path=test_data_path.joinpath("NoSketches", "NotSketch", "NotSketch.foo")) is False
 
-    # Sketch folder
+    # Sketch folder with .ino sketch file
     assert compilesketches.path_is_sketch(
         path=test_data_path.joinpath("HasSketches", "Sketch1")) is True
+
+    # Sketch folder with .pde sketch file
+    assert compilesketches.path_is_sketch(
+        path=test_data_path.joinpath("HasSketches", "Sketch2")) is True
 
     # No files in path
     assert compilesketches.path_is_sketch(


### PR DESCRIPTION
Previously, only sketches that use the .ino file extension were recognized.

There are still popular libraries and sketches that use the .pde extension, which are either unmaintained or with maintainers who have no interest in changing the extension ([reference](https://groups.google.com/a/arduino.cc/d/msg/developers/CHHJfU1f_8E/aMo27qy8BgAJ)), so support for .pde is required for this action to be a general purpose tool for compilation testing of all Arduino projects.