### PR TITLE
libraries/compile-examples: fix automatic platform dependency detection when FQBN uses custom board option

### DIFF
--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -214,7 +214,8 @@ class CompileSketches:
     def get_fqbn_platform_dependency(self):
         """Return the platform dependency definition automatically generated from the FQBN."""
         # Extract the platform name from the FQBN (e.g., arduino:avr:uno => arduino:avr)
-        fqbn_platform_dependency = {self.dependency_name_key: self.fqbn.rsplit(sep=":", maxsplit=1)[0]}
+        fqbn_component_list = self.fqbn.split(sep=":")
+        fqbn_platform_dependency = {self.dependency_name_key: fqbn_component_list[0] + ":" + fqbn_component_list[1]}
         if self.additional_url is not None:
             fqbn_platform_dependency[self.dependency_source_url_key] = self.additional_url
 

--- a/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
+++ b/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
@@ -338,7 +338,9 @@ def test_install_platforms(mocker, platforms):
     [("arduino:avr:uno", "arduino:avr", None),
      # FQBN with space, additional Board Manager URL
      ('\'"foo bar:baz:asdf" "https://example.com/platform_foo_index.json"\'', "foo bar:baz",
-      "https://example.com/platform_foo_index.json")]
+      "https://example.com/platform_foo_index.json"),
+     # Custom board option
+     ("arduino:avr:nano:cpu=atmega328old", "arduino:avr", None)]
 )
 def test_get_fqbn_platform_dependency(fqbn_arg, expected_platform, expected_additional_url):
     compile_sketches = get_compilesketches_object(fqbn_arg=fqbn_arg)


### PR DESCRIPTION
Before this fix, if the FQBN uses a custom board option and the `platform` input is not provided, the action fails:
https://github.com/arduino-libraries/ArduinoBLE/runs/868536766#step:4:12