### PR TITLE
libraries/compile-examples: enable deltas reporting on pushes

### DIFF
--- a/libraries/compile-examples/README.md
+++ b/libraries/compile-examples/README.md
@@ -119,7 +119,7 @@ GitHub access token used to get information from the GitHub API. Only needed if 
 
 ### `enable-size-deltas-report`
 
-Set to `true` to cause the action to determine the change in memory usage of the compiled sketches between the pull request branch and the tip of the pull request's base branch. This may be used with the [`arduino/actions/libraries/report-size-deltas` action](https://github.com/arduino/actions/tree/master/libraries/report-size-deltas). Default `false`.
+Set to `true` to cause the action to determine the change in memory usage of the compiled sketches. If the workflow is triggered by a `pull_request` event, the comparison is between the pull request branch and the tip of the pull request's base branch. If the workflow is triggered by a `push` event, the comparison is between the pushed commit and its immediate parent. This may be used with the [`arduino/actions/libraries/report-size-deltas` action](https://github.com/arduino/actions/tree/master/libraries/report-size-deltas). Default `false`.
 
 ## Example usage
 

--- a/libraries/compile-examples/action.yml
+++ b/libraries/compile-examples/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: 'GitHub access token used to get information from the GitHub API. Only needed if you are using the size deltas report feature with a private repository.'
     default: ''
   enable-size-deltas-report:
-    description: 'Set to true to cause the action to determine the change in memory usage of the compiled sketches between the head and base refs of a PR'
+    description: 'Set to true to cause the action to determine the change in memory usage of the compiled sketches between the head and base refs of a PR and the immediate parent commit of a push'
     default: false
 runs:
   using: 'docker'


### PR DESCRIPTION
Previously, the action only allowed reporting of memory usage change when the workflow was triggered by a `pull_request` event. This meant the action could only be used to determine the impact of changes proposed via pull requests. This information can also be useful to have either when pushing commits to a feature branch in preparation for a pull request, or for development work flows where pull requests are not always used (as is very common for individual Arduino projects).

This will result in longer push triggered workflow run duration for people with the `enable-size-deltas` input set to `true`, but no other impact. If the previous behavior of only reporting deltas for workflows triggered by a `pull_request` event is desired, this can be achieved using GitHub Actions expression syntax , by changing the `enable-size-deltas` input's value from `true` to:
`${{ github.event_name == 'pull_request' }}`