### PR TITLE
Use Python 3.8.5 for testing and running libraries Python actions

### DIFF
--- a/.github/workflows/libraries_compile-examples.yml
+++ b/.github/workflows/libraries_compile-examples.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8.3'
+          python-version: '3.8.5'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/libraries_report-size-deltas.yml
+++ b/.github/workflows/libraries_report-size-deltas.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8.3'
+          python-version: '3.8.5'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/libraries_report-size-trends.yml
+++ b/.github/workflows/libraries_report-size-trends.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8.3'
+          python-version: '3.8.5'
 
       - name: Install dependencies
         run: |

--- a/libraries/compile-examples/Dockerfile
+++ b/libraries/compile-examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.3
+FROM python:3.8.5
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY compilesketches /compilesketches

--- a/libraries/report-size-deltas/Dockerfile
+++ b/libraries/report-size-deltas/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.3
+FROM python:3.8.5
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY reportsizedeltas.py /reportsizedeltas.py

--- a/libraries/report-size-trends/Dockerfile
+++ b/libraries/report-size-trends/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.3
+FROM python:3.8.5
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY reportsizetrends /reportsizetrends


### PR DESCRIPTION
The GitHub Actions `actions/setup-python` action no longer offers Python 3.8.3, so it's necessary to update the CI workflow to use Python 3.8.5. It makes sense to use the same Python version for running the action as is used for testing the action, so I also updated the Docker image to python:3.8.5.