### PR TITLE
Structure sketches report to allow compiling for multiple boards per run

### DIFF
--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -80,6 +80,7 @@ class CompileSketches:
     board_manager_platforms_path = arduino_cli_data_directory_path.joinpath("packages")
 
     class ReportKeys:
+        boards = "boards"
         board = "board"
         commit_hash = "commit_hash"
         commit_url = "commit_url"
@@ -957,7 +958,7 @@ class CompileSketches:
         return size_report
 
     def get_sketches_report(self, sketch_report_list):
-        """Return the dictionary containing data on all sketch compilations
+        """Return the dictionary containing data on all sketch compilations for each board
 
         Keyword arguments:
         sketch_report_list -- list of reports from each sketch compilation
@@ -965,18 +966,25 @@ class CompileSketches:
         current_git_ref = get_head_commit_hash()
 
         sketches_report = {
-            self.ReportKeys.board: self.fqbn,
             self.ReportKeys.commit_hash: current_git_ref,
             self.ReportKeys.commit_url: ("https://github.com/"
                                          + os.environ["GITHUB_REPOSITORY"]
                                          + "/commit/"
                                          + current_git_ref),
-            self.ReportKeys.sketches: sketch_report_list
+            # The action is currently designed to only compile for one board per run, so the boards list will only have
+            # a single element, but this provides a report format that can accommodate the possible addition of multiple
+            # boards support
+            self.ReportKeys.boards: [
+                {
+                    self.ReportKeys.board: self.fqbn,
+                    self.ReportKeys.sketches: sketch_report_list
+                }
+            ]
         }
 
         sizes_summary_report = self.get_sizes_summary_report(sketch_report_list=sketch_report_list)
         if sizes_summary_report:
-            sketches_report[self.ReportKeys.sizes] = sizes_summary_report
+            sketches_report[self.ReportKeys.boards][0][self.ReportKeys.sizes] = sizes_summary_report
 
         return sketches_report
 

--- a/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
+++ b/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
@@ -1559,14 +1559,18 @@ def test_get_sketches_report(monkeypatch, mocker):
     compile_sketches = get_compilesketches_object(fqbn_arg=fqbn_arg)
 
     assert compile_sketches.get_sketches_report(sketch_report_list=sketch_report_list) == {
-        compilesketches.CompileSketches.ReportKeys.board: compile_sketches.fqbn,
         compilesketches.CompileSketches.ReportKeys.commit_hash: current_git_ref,
         compilesketches.CompileSketches.ReportKeys.commit_url: ("https://github.com/"
                                                                 + github_repository
                                                                 + "/commit/"
                                                                 + current_git_ref),
-        compilesketches.CompileSketches.ReportKeys.sizes: sizes_summary_report,
-        compilesketches.CompileSketches.ReportKeys.sketches: sketch_report_list
+        compilesketches.CompileSketches.ReportKeys.boards: [
+            {
+                compilesketches.CompileSketches.ReportKeys.board: compile_sketches.fqbn,
+                compilesketches.CompileSketches.ReportKeys.sizes: sizes_summary_report,
+                compilesketches.CompileSketches.ReportKeys.sketches: sketch_report_list
+            }
+        ]
     }
 
     compile_sketches.get_sizes_summary_report.assert_called_once_with(compile_sketches,
@@ -1576,13 +1580,17 @@ def test_get_sketches_report(monkeypatch, mocker):
     compilesketches.CompileSketches.get_sizes_summary_report.return_value = []
 
     assert compile_sketches.get_sketches_report(sketch_report_list=sketch_report_list) == {
-        compilesketches.CompileSketches.ReportKeys.board: compile_sketches.fqbn,
         compilesketches.CompileSketches.ReportKeys.commit_hash: current_git_ref,
         compilesketches.CompileSketches.ReportKeys.commit_url: ("https://github.com/"
                                                                 + github_repository
                                                                 + "/commit/"
                                                                 + current_git_ref),
-        compilesketches.CompileSketches.ReportKeys.sketches: sketch_report_list
+        compilesketches.CompileSketches.ReportKeys.boards: [
+            {
+                compilesketches.CompileSketches.ReportKeys.board: compile_sketches.fqbn,
+                compilesketches.CompileSketches.ReportKeys.sketches: sketch_report_list
+            }
+        ]
     }
 
 
@@ -1816,7 +1824,7 @@ def test_get_sizes_summary_report():
 
 def test_create_sketches_report_file(monkeypatch, tmp_path):
     sketches_report_path = tmp_path
-    sketches_report = {
+    sketches_report = [{
         "sketch": "examples/Foo",
         "compilation_success": True,
         "flash": 444,
@@ -1826,7 +1834,7 @@ def test_create_sketches_report_file(monkeypatch, tmp_path):
         "flash_delta": -994,
         "ram_delta": -175,
         "fqbn": "arduino:avr:uno"
-    }
+    }]
 
     compile_sketches = get_compilesketches_object(sketches_report_path=str(sketches_report_path),
                                                   fqbn_arg="arduino:avr:uno")

--- a/libraries/report-size-deltas/tests/data/size-deltas-reports-new/arduino-avr-leonardo.json
+++ b/libraries/report-size-deltas/tests/data/size-deltas-reports-new/arduino-avr-leonardo.json
@@ -1,87 +1,91 @@
 {
-  "board": "arduino:avr:leonardo",
   "commit_hash": "d8fd302",
   "commit_url": "https://example.com/foo",
-  "sketches": [
+  "boards": [
     {
-      "name": "examples/Bar",
-      "compilation_success": true,
+      "board": "arduino:avr:leonardo",
+      "sketches": [
+        {
+          "name": "examples/Bar",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "current": {
+                "absolute": 3494
+              },
+              "previous": {
+                "absolute": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A"
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "current": {
+                "absolute": 153
+              },
+              "previous": {
+                "absolute": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A"
+              }
+            }
+          ]
+        },
+        {
+          "name": "examples/Foo",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "current": {
+                "absolute": 3462
+              },
+              "previous": {
+                "absolute": 3474
+              },
+              "delta": {
+                "absolute": -12
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "current": {
+                "absolute": 149
+              },
+              "previous": {
+                "absolute": 149
+              },
+              "delta": {
+                "absolute": 0
+              }
+            }
+          ]
+        }
+      ],
       "sizes": [
         {
           "name": "flash",
-          "current": {
-            "absolute": 3494
-          },
-          "previous": {
-            "absolute": "N/A"
-          },
           "delta": {
-            "absolute": "N/A"
+            "absolute": {
+              "minimum": -12,
+              "maximum": -12
+            }
           }
         },
         {
           "name": "RAM for global variables",
-          "current": {
-            "absolute": 153
-          },
-          "previous": {
-            "absolute": "N/A"
-          },
           "delta": {
-            "absolute": "N/A"
+            "absolute": {
+              "minimum": 0,
+              "maximum": 0
+            }
           }
         }
       ]
-    },
-    {
-      "name": "examples/Foo",
-      "compilation_success": true,
-      "sizes": [
-        {
-          "name": "flash",
-          "current": {
-            "absolute": 3462
-          },
-          "previous": {
-            "absolute": 3474
-          },
-          "delta": {
-            "absolute": -12
-          }
-        },
-        {
-          "name": "RAM for global variables",
-          "current": {
-            "absolute": 149
-          },
-          "previous": {
-            "absolute": 149
-          },
-          "delta": {
-            "absolute": 0
-          }
-        }
-      ]
-    }
-  ],
-  "sizes": [
-    {
-      "name": "flash",
-      "delta": {
-        "absolute": {
-          "minimum": -12,
-          "maximum": -12
-        }
-      }
-    },
-    {
-      "name": "RAM for global variables",
-      "delta": {
-        "absolute": {
-          "minimum": 0,
-          "maximum": 0
-        }
-      }
     }
   ]
 }

--- a/libraries/report-size-deltas/tests/data/size-deltas-reports-new/arduino-avr-uno.json
+++ b/libraries/report-size-deltas/tests/data/size-deltas-reports-new/arduino-avr-uno.json
@@ -1,87 +1,91 @@
 {
-  "board": "arduino:avr:uno",
   "commit_hash": "d8fd302",
   "commit_url": "https://example.com/foo",
-  "sketches": [
+  "boards": [
     {
-      "name": "examples/Bar",
-      "compilation_success": true,
+      "board": "arduino:avr:uno",
+      "sketches": [
+        {
+          "name": "examples/Bar",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "current": {
+                "absolute": 1460
+              },
+              "previous": {
+                "absolute": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A"
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "current": {
+                "absolute": 190
+              },
+              "previous": {
+                "absolute": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A"
+              }
+            }
+          ]
+        },
+        {
+          "name": "examples/Foo",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "current": {
+                "absolute": 444
+              },
+              "previous": {
+                "absolute": 1438
+              },
+              "delta": {
+                "absolute": -994
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "current": {
+                "absolute": 9
+              },
+              "previous": {
+                "absolute": 184
+              },
+              "delta": {
+                "absolute": -175
+              }
+            }
+          ]
+        }
+      ],
       "sizes": [
         {
           "name": "flash",
-          "current": {
-            "absolute": 1460
-          },
-          "previous": {
-            "absolute": "N/A"
-          },
           "delta": {
-            "absolute": "N/A"
+            "absolute": {
+              "minimum": -994,
+              "maximum": -994
+            }
           }
         },
         {
           "name": "RAM for global variables",
-          "current": {
-            "absolute": 190
-          },
-          "previous": {
-            "absolute": "N/A"
-          },
           "delta": {
-            "absolute": "N/A"
+            "absolute": {
+              "minimum": -175,
+              "maximum": -175
+            }
           }
         }
       ]
-    },
-    {
-      "name": "examples/Foo",
-      "compilation_success": true,
-      "sizes": [
-        {
-          "name": "flash",
-          "current": {
-            "absolute": 444
-          },
-          "previous": {
-            "absolute": 1438
-          },
-          "delta": {
-            "absolute": -994
-          }
-        },
-        {
-          "name": "RAM for global variables",
-          "current": {
-            "absolute": 9
-          },
-          "previous": {
-            "absolute": 184
-          },
-          "delta": {
-            "absolute": -175
-          }
-        }
-      ]
-    }
-  ],
-  "sizes": [
-    {
-      "name": "flash",
-      "delta": {
-        "absolute": {
-          "minimum": -994,
-          "maximum": -994
-        }
-      }
-    },
-    {
-      "name": "RAM for global variables",
-      "delta": {
-        "absolute": {
-          "minimum": -175,
-          "maximum": -175
-        }
-      }
     }
   ]
 }

--- a/libraries/report-size-deltas/tests/data/size-deltas-reports-old/arduino-samd-mkrgsm1400.json
+++ b/libraries/report-size-deltas/tests/data/size-deltas-reports-old/arduino-samd-mkrgsm1400.json
@@ -1,10 +1,87 @@
 {
-  "fqbn": "arduino:samd:mkrgsm1400",
-  "sketch": "examples/ConnectionHandlerDemo",
-  "previous_flash": "N/A",
-  "flash": 51636,
-  "flash_delta": "N/A",
-  "previous_ram": "N/A",
-  "ram": 5104,
-  "ram_delta": "N/A"
+  "board": "arduino:samd:mkrgsm1400",
+  "commit_hash": "d8fd302",
+  "commit_url": "https://example.com/foo",
+  "sketches": [
+    {
+      "name": "examples/ConnectionHandlerDemo",
+      "compilation_success": true,
+      "sizes": [
+        {
+          "name": "flash",
+          "current": {
+            "absolute": 1460
+          },
+          "previous": {
+            "absolute": "N/A"
+          },
+          "delta": {
+            "absolute": "N/A"
+          }
+        },
+        {
+          "name": "RAM for global variables",
+          "current": {
+            "absolute": 190
+          },
+          "previous": {
+            "absolute": "N/A"
+          },
+          "delta": {
+            "absolute": "N/A"
+          }
+        }
+      ]
+    },
+    {
+      "name": "examples/Foo",
+      "compilation_success": true,
+      "sizes": [
+        {
+          "name": "flash",
+          "current": {
+            "absolute": 444
+          },
+          "previous": {
+            "absolute": 1438
+          },
+          "delta": {
+            "absolute": -994
+          }
+        },
+        {
+          "name": "RAM for global variables",
+          "current": {
+            "absolute": 9
+          },
+          "previous": {
+            "absolute": 184
+          },
+          "delta": {
+            "absolute": -175
+          }
+        }
+      ]
+    }
+  ],
+  "sizes": [
+    {
+      "name": "flash",
+      "delta": {
+        "absolute": {
+          "minimum": -994,
+          "maximum": -994
+        }
+      }
+    },
+    {
+      "name": "RAM for global variables",
+      "delta": {
+        "absolute": {
+          "minimum": -175,
+          "maximum": -175
+        }
+      }
+    }
+  ]
 }

--- a/libraries/report-size-deltas/tests/test_reportsizedeltas.py
+++ b/libraries/report-size-deltas/tests/test_reportsizedeltas.py
@@ -379,85 +379,89 @@ def test_get_artifact(tmp_path, test_artifact_name, expected_success):
                 {
                     report_keys.commit_hash: "d8fd302",
                     report_keys.commit_url: "https://example.com/foo",
-                    report_keys.board: "arduino:avr:leonardo",
-                    report_keys.sizes: [
+                    report_keys.boards: [
                         {
-                            report_keys.delta: {
-                                report_keys.absolute: {
-                                    report_keys.maximum: -12,
-                                    report_keys.minimum: -12
-                                }
-                            },
-                            report_keys.name: "flash"
-                        },
-                        {
-                            report_keys.delta: {
-                                report_keys.absolute: {
-                                    report_keys.maximum: 0,
-                                    report_keys.minimum: 0
-                                }
-                            },
-                            report_keys.name: "RAM for global variables"
-                        }
-                    ],
-                    report_keys.sketches: [
-                        {
-                            report_keys.compilation_success: True,
-                            report_keys.name: "examples/Bar",
+                            report_keys.board: "arduino:avr:leonardo",
                             report_keys.sizes: [
                                 {
-                                    report_keys.current: {
-                                        report_keys.absolute: 3494
-                                    },
                                     report_keys.delta: {
-                                        report_keys.absolute: "N/A"
+                                        report_keys.absolute: {
+                                            report_keys.maximum: -12,
+                                            report_keys.minimum: -12
+                                        }
                                     },
-                                    report_keys.name: "flash",
-                                    "previous": {
-                                        report_keys.absolute: "N/A"
-                                    }
+                                    report_keys.name: "flash"
                                 },
                                 {
-                                    report_keys.current: {
-                                        report_keys.absolute: 153
-                                    },
                                     report_keys.delta: {
-                                        report_keys.absolute: "N/A"
+                                        report_keys.absolute: {
+                                            report_keys.maximum: 0,
+                                            report_keys.minimum: 0
+                                        }
                                     },
-                                    report_keys.name: "RAM for global variables",
-                                    "previous": {
-                                        report_keys.absolute: "N/A"
-                                    }
+                                    report_keys.name: "RAM for global variables"
                                 }
-                            ]
-                        },
-                        {
-                            report_keys.compilation_success: True,
-                            report_keys.name: "examples/Foo",
-                            report_keys.sizes: [
+                            ],
+                            report_keys.sketches: [
                                 {
-                                    report_keys.current: {
-                                        report_keys.absolute: 3462
-                                    },
-                                    report_keys.delta: {
-                                        report_keys.absolute: -12
-                                    },
-                                    report_keys.name: "flash",
-                                    "previous": {
-                                        report_keys.absolute: 3474
-                                    }
+                                    report_keys.compilation_success: True,
+                                    report_keys.name: "examples/Bar",
+                                    report_keys.sizes: [
+                                        {
+                                            report_keys.current: {
+                                                report_keys.absolute: 3494
+                                            },
+                                            report_keys.delta: {
+                                                report_keys.absolute: "N/A"
+                                            },
+                                            report_keys.name: "flash",
+                                            "previous": {
+                                                report_keys.absolute: "N/A"
+                                            }
+                                        },
+                                        {
+                                            report_keys.current: {
+                                                report_keys.absolute: 153
+                                            },
+                                            report_keys.delta: {
+                                                report_keys.absolute: "N/A"
+                                            },
+                                            report_keys.name: "RAM for global variables",
+                                            "previous": {
+                                                report_keys.absolute: "N/A"
+                                            }
+                                        }
+                                    ]
                                 },
                                 {
-                                    report_keys.current: {
-                                        report_keys.absolute: 149
-                                    },
-                                    report_keys.delta: {
-                                        report_keys.absolute: 0
-                                    },
-                                    report_keys.name: "RAM for global variables",
-                                    "previous": {
-                                        report_keys.absolute: 149
-                                    }
+                                    report_keys.compilation_success: True,
+                                    report_keys.name: "examples/Foo",
+                                    report_keys.sizes: [
+                                        {
+                                            report_keys.current: {
+                                                report_keys.absolute: 3462
+                                            },
+                                            report_keys.delta: {
+                                                report_keys.absolute: -12
+                                            },
+                                            report_keys.name: "flash",
+                                            "previous": {
+                                                report_keys.absolute: 3474
+                                            }
+                                        },
+                                        {
+                                            report_keys.current: {
+                                                report_keys.absolute: 149
+                                            },
+                                            report_keys.delta: {
+                                                report_keys.absolute: 0
+                                            },
+                                            report_keys.name: "RAM for global variables",
+                                            "previous": {
+                                                report_keys.absolute: 149
+                                            }
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -466,85 +470,89 @@ def test_get_artifact(tmp_path, test_artifact_name, expected_success):
                 {
                     report_keys.commit_hash: "d8fd302",
                     report_keys.commit_url: "https://example.com/foo",
-                    report_keys.board: "arduino:avr:uno",
-                    report_keys.sizes: [
+                    report_keys.boards: [
                         {
-                            report_keys.delta: {
-                                report_keys.absolute: {
-                                    report_keys.maximum: -994,
-                                    report_keys.minimum: -994
-                                }
-                            },
-                            report_keys.name: "flash"
-                        },
-                        {
-                            report_keys.delta: {
-                                report_keys.absolute: {
-                                    report_keys.maximum: -175,
-                                    report_keys.minimum: -175
-                                }
-                            },
-                            report_keys.name: "RAM for global variables"
-                        }
-                    ],
-                    report_keys.sketches: [
-                        {
-                            report_keys.compilation_success: True,
-                            report_keys.name: "examples/Bar",
+                            report_keys.board: "arduino:avr:uno",
                             report_keys.sizes: [
                                 {
-                                    report_keys.current: {
-                                        report_keys.absolute: 1460
-                                    },
                                     report_keys.delta: {
-                                        report_keys.absolute: "N/A"
+                                        report_keys.absolute: {
+                                            report_keys.maximum: -994,
+                                            report_keys.minimum: -994
+                                        }
                                     },
-                                    report_keys.name: "flash",
-                                    "previous": {
-                                        report_keys.absolute: "N/A"
-                                    }
+                                    report_keys.name: "flash"
                                 },
                                 {
-                                    report_keys.current: {
-                                        report_keys.absolute: 190
-                                    },
                                     report_keys.delta: {
-                                        report_keys.absolute: "N/A"
+                                        report_keys.absolute: {
+                                            report_keys.maximum: -175,
+                                            report_keys.minimum: -175
+                                        }
                                     },
-                                    report_keys.name: "RAM for global variables",
-                                    "previous": {
-                                        report_keys.absolute: "N/A"
-                                    }
+                                    report_keys.name: "RAM for global variables"
                                 }
-                            ]
-                        },
-                        {
-                            report_keys.compilation_success: True,
-                            report_keys.name: "examples/Foo",
-                            report_keys.sizes: [
+                            ],
+                            report_keys.sketches: [
                                 {
-                                    report_keys.current: {
-                                        report_keys.absolute: 444
-                                    },
-                                    report_keys.delta: {
-                                        report_keys.absolute: -994
-                                    },
-                                    report_keys.name: "flash",
-                                    "previous": {
-                                        report_keys.absolute: 1438
-                                    }
+                                    report_keys.compilation_success: True,
+                                    report_keys.name: "examples/Bar",
+                                    report_keys.sizes: [
+                                        {
+                                            report_keys.current: {
+                                                report_keys.absolute: 1460
+                                            },
+                                            report_keys.delta: {
+                                                report_keys.absolute: "N/A"
+                                            },
+                                            report_keys.name: "flash",
+                                            "previous": {
+                                                report_keys.absolute: "N/A"
+                                            }
+                                        },
+                                        {
+                                            report_keys.current: {
+                                                report_keys.absolute: 190
+                                            },
+                                            report_keys.delta: {
+                                                report_keys.absolute: "N/A"
+                                            },
+                                            report_keys.name: "RAM for global variables",
+                                            "previous": {
+                                                report_keys.absolute: "N/A"
+                                            }
+                                        }
+                                    ]
                                 },
                                 {
-                                    report_keys.current: {
-                                        report_keys.absolute: 9
-                                    },
-                                    report_keys.delta: {
-                                        report_keys.absolute: -175
-                                    },
-                                    report_keys.name: "RAM for global variables",
-                                    "previous": {
-                                        report_keys.absolute: 184
-                                    }
+                                    report_keys.compilation_success: True,
+                                    report_keys.name: "examples/Foo",
+                                    report_keys.sizes: [
+                                        {
+                                            report_keys.current: {
+                                                report_keys.absolute: 444
+                                            },
+                                            report_keys.delta: {
+                                                report_keys.absolute: -994
+                                            },
+                                            report_keys.name: "flash",
+                                            "previous": {
+                                                report_keys.absolute: 1438
+                                            }
+                                        },
+                                        {
+                                            report_keys.current: {
+                                                report_keys.absolute: 9
+                                            },
+                                            report_keys.delta: {
+                                                report_keys.absolute: -175
+                                            },
+                                            report_keys.name: "RAM for global variables",
+                                            "previous": {
+                                                report_keys.absolute: 184
+                                            }
+                                        }
+                                    ]
                                 }
                             ]
                         }


### PR DESCRIPTION
This changes the report generated by the `arduino/actions/libraries/compile-examples` action to use of an array of objects containing compilation data associated with a specific FQBN .

Although the action does not currently support multiple boards per run, this new format makes the report structure able to accomodate data for multiple boards.

As time goes on, it becomes more likely for there to be 3rd party uses of the report, which would be broken by changes to its structure, so it's worth trying to finalize the format now.

Although this is a breaking change to the report structure, the actions that use the report are updated to use the new format, so there is no breakage for the report's intended uses. The `arduino/actions/libraries/report-size-deltas` action is able to detect and ignore leftover reports from before the format change.

---
Example of previous report format:
```json
{
  "board": "arduino:samd:mkrwifi1010",
  "commit_hash": "1cf0755c06c1302e22f4fde30ba36bf131f3143b",
  "commit_url": "https://github.com/per1234/ArduinoIoTCloud/commit/1cf0755c06c1302e22f4fde30ba36bf131f3143b",
    "sketches": [
      {
        "name": "examples/ArduinoIoTCloud-Advanced",
        "compilation_success": true,
        "sizes": [
          {
            "name": "flash",
            "current": {
              "absolute": 145664
            },
            "previous": {
              "absolute": 145664
            },
            "delta": {
              "absolute": 0
            }
          },
          {
            "name": "RAM for global variables",
            "current": {
              "absolute": 21396
            },
            "previous": {
              "absolute": 21396
            },
            "delta": {
              "absolute": 0
            }
          }
        ]
      }
    ],
    "sizes": [
      {
        "name": "flash",
        "delta": {
          "absolute": {
            "minimum": 0,
            "maximum": 16
          }
        }
      },
      {
        "name": "RAM for global variables",
        "delta": {
          "absolute": {
            "minimum": 0,
            "maximum": 0
          }
        }
      }
    ]
  }
}
```

---
That report in the new format:
```json
{
  "commit_hash": "1cf0755c06c1302e22f4fde30ba36bf131f3143b",
  "commit_url": "https://github.com/per1234/ArduinoIoTCloud/commit/1cf0755c06c1302e22f4fde30ba36bf131f3143b",
  "boards": [
    {
      "board": "arduino:samd:mkrwifi1010",
      "sketches": [
        {
          "name": "examples/ArduinoIoTCloud-Advanced",
          "compilation_success": true,
          "sizes": [
            {
              "name": "flash",
              "current": {
                "absolute": 145664
              },
              "previous": {
                "absolute": 145664
              },
              "delta": {
                "absolute": 0
              }
            },
            {
              "name": "RAM for global variables",
              "current": {
                "absolute": 21396
              },
              "previous": {
                "absolute": 21396
              },
              "delta": {
                "absolute": 0
              }
            }
          ]
        }
      ],
      "sizes": [
        {
          "name": "flash",
          "delta": {
            "absolute": {
              "minimum": 0,
              "maximum": 16
            }
          }
        },
        {
          "name": "RAM for global variables",
          "delta": {
            "absolute": {
              "minimum": 0,
              "maximum": 0
            }
          }
        }
      ]
    }
  ]
}
```