### PR TITLE
libraries/compile-examples: prevent unnecessary GitHub API request

### DIFF
--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -126,13 +126,18 @@ class CompileSketches:
         else:
             self.github_api = github.Github(login_or_token=github_token)
 
-        self.deltas_base_ref = self.get_deltas_base_ref()
-
         self.enable_size_deltas_report = parse_boolean_input(boolean_input=enable_size_deltas_report)
         # The enable-size-deltas-report input has a default value so it should always be either True or False
         if self.enable_size_deltas_report is None:
             print("::error::Invalid value for enable-size-deltas-report input")
             sys.exit(1)
+
+        if self.enable_size_deltas_report:
+            self.deltas_base_ref = self.get_deltas_base_ref()
+        else:
+            # If deltas reports are not enabled, there is no use for the base ref and it could result in an GitHub API
+            # request which requires a GitHub token when used in a private repository
+            self.deltas_base_ref = None
 
         self.sketches_report_path = pathlib.PurePath(sketches_report_path)
 

--- a/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
+++ b/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
@@ -208,6 +208,10 @@ def test_compilesketches():
     with pytest.raises(expected_exception=SystemExit, match="1"):
         get_compilesketches_object(enable_size_deltas_report="fooInvalidEnableSizeDeltasBoolean")
 
+    # Test deltas_base_ref when size deltas report is disabled
+    compile_sketches = get_compilesketches_object(enable_size_deltas_report="false")
+    assert compile_sketches.deltas_base_ref is None
+
 
 @pytest.mark.parametrize("event_name, expected_ref",
                          [("pull_request", unittest.mock.sentinel.pull_request_base_ref),
@@ -1443,7 +1447,7 @@ def test_checkout_deltas_base_ref(monkeypatch, mocker):
         def checkout(self):
             pass
 
-    compile_sketches = get_compilesketches_object(deltas_base_ref=deltas_base_ref)
+    compile_sketches = get_compilesketches_object(enable_size_deltas_report="true", deltas_base_ref=deltas_base_ref)
 
     mocker.patch("git.Repo", autospec=True, return_value=Repo())
     mocker.patch.object(Repo, "fetch")


### PR DESCRIPTION
In order to access information about private repositories via the GitHub API, a GitHub access token is required.

The only use of the GitHub API by the action is in determining the base ref of the pull request to use for reporting size deltas.

A change was inadvertently made that caused this GitHub API request to be made every time the action was run, even when size deltas reporting was disabled. This resulted in the action failing when triggered from a private repository when the `github-token` input was not provided by the workflow.