### PR TITLE
libraries/compile-examples, libraries/report-size-deltas: Report relative memory usage data

### DIFF
--- a/libraries/report-size-deltas/tests/data/size-deltas-reports-new/arduino-avr-leonardo.json
+++ b/libraries/report-size-deltas/tests/data/size-deltas-reports-new/arduino-avr-leonardo.json
@@ -11,26 +11,34 @@
           "sizes": [
             {
               "name": "flash",
+              "maximum": 28672,
               "current": {
-                "absolute": 3494
+                "absolute": 3494,
+                "relative": 12.19
               },
               "previous": {
-                "absolute": "N/A"
+                "absolute": "N/A",
+                "relative": "N/A"
               },
               "delta": {
-                "absolute": "N/A"
+                "absolute": "N/A",
+                "relative": "N/A"
               }
             },
             {
               "name": "RAM for global variables",
+              "maximum": 2560,
               "current": {
-                "absolute": 153
+                "absolute": 153,
+                "relative": 5.97
               },
               "previous": {
-                "absolute": "N/A"
+                "absolute": "N/A",
+                "relative": "N/A"
               },
               "delta": {
-                "absolute": "N/A"
+                "absolute": "N/A",
+                "relative": "N/A"
               }
             }
           ]
@@ -41,26 +49,34 @@
           "sizes": [
             {
               "name": "flash",
+              "maximum": 28672,
               "current": {
-                "absolute": 3462
+                "absolute": 3462,
+                "relative": 12.07
               },
               "previous": {
-                "absolute": 3474
+                "absolute": 3474,
+                "relative": 12.12
               },
               "delta": {
-                "absolute": -12
+                "absolute": -12,
+                "relative": -0.05
               }
             },
             {
               "name": "RAM for global variables",
+              "maximum": 2560,
               "current": {
-                "absolute": 149
+                "absolute": 149,
+                "relative": 5.82
               },
               "previous": {
-                "absolute": 149
+                "absolute": 149,
+                "relative": 5.82
               },
               "delta": {
-                "absolute": 0
+                "absolute": 0,
+                "relative": 0.0
               }
             }
           ]
@@ -69,19 +85,29 @@
       "sizes": [
         {
           "name": "flash",
+          "maximum": 28672,
           "delta": {
             "absolute": {
               "minimum": -12,
               "maximum": -12
+            },
+            "relative": {
+              "minimum": -0.05,
+              "maximum": -0.05
             }
           }
         },
         {
           "name": "RAM for global variables",
+          "maximum": 2560,
           "delta": {
             "absolute": {
               "minimum": 0,
               "maximum": 0
+            },
+            "relative": {
+              "minimum": 0.0,
+              "maximum": 0.0
             }
           }
         }

--- a/libraries/report-size-deltas/tests/data/size-deltas-reports-new/arduino-avr-uno.json
+++ b/libraries/report-size-deltas/tests/data/size-deltas-reports-new/arduino-avr-uno.json
@@ -11,26 +11,34 @@
           "sizes": [
             {
               "name": "flash",
+              "maximum": 32256,
               "current": {
-                "absolute": 1460
+                "absolute": 1460,
+                "relative": 4.53
               },
               "previous": {
-                "absolute": "N/A"
+                "absolute": "N/A",
+                "relative": "N/A"
               },
               "delta": {
-                "absolute": "N/A"
+                "absolute": "N/A",
+                "relative": "N/A"
               }
             },
             {
               "name": "RAM for global variables",
+              "maximum": 2048,
               "current": {
-                "absolute": 190
+                "absolute": 190,
+                "relative": 9.28
               },
               "previous": {
-                "absolute": "N/A"
+                "absolute": "N/A",
+                "relative": "N/A"
               },
               "delta": {
-                "absolute": "N/A"
+                "absolute": "N/A",
+                "relative": "N/A"
               }
             }
           ]
@@ -41,26 +49,34 @@
           "sizes": [
             {
               "name": "flash",
+              "maximum": 32256,
               "current": {
-                "absolute": 444
+                "absolute": 444,
+                "relative": 1.38
               },
               "previous": {
-                "absolute": 1438
+                "absolute": 1438,
+                "relative": 4.46
               },
               "delta": {
-                "absolute": -994
+                "absolute": -994,
+                "relative": -3.08
               }
             },
             {
               "name": "RAM for global variables",
+              "maximum": 2048,
               "current": {
-                "absolute": 9
+                "absolute": 9,
+                "relative": 0.44
               },
               "previous": {
-                "absolute": 184
+                "absolute": 184,
+                "relative": 8.98
               },
               "delta": {
-                "absolute": -175
+                "absolute": -175,
+                "relative": -8.54
               }
             }
           ]
@@ -69,19 +85,29 @@
       "sizes": [
         {
           "name": "flash",
+          "maximum": 32256,
           "delta": {
             "absolute": {
               "minimum": -994,
               "maximum": -994
+            },
+            "relative": {
+              "minimum": -3.08,
+              "maximum": -3.08
             }
           }
         },
         {
           "name": "RAM for global variables",
+          "maximum": 2048,
           "delta": {
             "absolute": {
               "minimum": -175,
               "maximum": -175
+            },
+            "relative": {
+              "minimum": -8.54,
+              "maximum": -8.54
             }
           }
         }

--- a/libraries/report-size-deltas/tests/test_reportsizedeltas.py
+++ b/libraries/report-size-deltas/tests/test_reportsizedeltas.py
@@ -388,18 +388,28 @@ def test_get_artifact(tmp_path, test_artifact_name, expected_success):
                                         report_keys.absolute: {
                                             report_keys.maximum: -12,
                                             report_keys.minimum: -12
+                                        },
+                                        report_keys.relative: {
+                                            report_keys.maximum: -0.05,
+                                            report_keys.minimum: -0.05
                                         }
                                     },
-                                    report_keys.name: "flash"
+                                    report_keys.name: "flash",
+                                    report_keys.maximum: 28672
                                 },
                                 {
                                     report_keys.delta: {
                                         report_keys.absolute: {
                                             report_keys.maximum: 0,
                                             report_keys.minimum: 0
+                                        },
+                                        report_keys.relative: {
+                                            report_keys.maximum: 0.00,
+                                            report_keys.minimum: 0.00
                                         }
                                     },
-                                    report_keys.name: "RAM for global variables"
+                                    report_keys.name: "RAM for global variables",
+                                    report_keys.maximum: 2560
                                 }
                             ],
                             report_keys.sketches: [
@@ -409,26 +419,34 @@ def test_get_artifact(tmp_path, test_artifact_name, expected_success):
                                     report_keys.sizes: [
                                         {
                                             report_keys.current: {
-                                                report_keys.absolute: 3494
+                                                report_keys.absolute: 3494,
+                                                report_keys.relative: 12.19
                                             },
                                             report_keys.delta: {
-                                                report_keys.absolute: "N/A"
+                                                report_keys.absolute: "N/A",
+                                                report_keys.relative: "N/A"
                                             },
                                             report_keys.name: "flash",
-                                            "previous": {
-                                                report_keys.absolute: "N/A"
+                                            report_keys.maximum: 28672,
+                                            report_keys.previous: {
+                                                report_keys.absolute: "N/A",
+                                                report_keys.relative: "N/A"
                                             }
                                         },
                                         {
                                             report_keys.current: {
-                                                report_keys.absolute: 153
+                                                report_keys.absolute: 153,
+                                                report_keys.relative: 5.97
                                             },
                                             report_keys.delta: {
-                                                report_keys.absolute: "N/A"
+                                                report_keys.absolute: "N/A",
+                                                report_keys.relative: "N/A"
                                             },
                                             report_keys.name: "RAM for global variables",
-                                            "previous": {
-                                                report_keys.absolute: "N/A"
+                                            report_keys.maximum: 2560,
+                                            report_keys.previous: {
+                                                report_keys.absolute: "N/A",
+                                                report_keys.relative: "N/A"
                                             }
                                         }
                                     ]
@@ -439,26 +457,34 @@ def test_get_artifact(tmp_path, test_artifact_name, expected_success):
                                     report_keys.sizes: [
                                         {
                                             report_keys.current: {
-                                                report_keys.absolute: 3462
+                                                report_keys.absolute: 3462,
+                                                report_keys.relative: 12.07
                                             },
                                             report_keys.delta: {
-                                                report_keys.absolute: -12
+                                                report_keys.absolute: -12,
+                                                report_keys.relative: -0.05
                                             },
                                             report_keys.name: "flash",
-                                            "previous": {
-                                                report_keys.absolute: 3474
+                                            report_keys.maximum: 28672,
+                                            report_keys.previous: {
+                                                report_keys.absolute: 3474,
+                                                report_keys.relative: 12.12
                                             }
                                         },
                                         {
                                             report_keys.current: {
-                                                report_keys.absolute: 149
+                                                report_keys.absolute: 149,
+                                                report_keys.relative: 5.82
                                             },
                                             report_keys.delta: {
-                                                report_keys.absolute: 0
+                                                report_keys.absolute: 0,
+                                                report_keys.relative: -0.00
                                             },
                                             report_keys.name: "RAM for global variables",
-                                            "previous": {
-                                                report_keys.absolute: 149
+                                            report_keys.maximum: 2560,
+                                            report_keys.previous: {
+                                                report_keys.absolute: 149,
+                                                report_keys.relative: 5.82
                                             }
                                         }
                                     ]
@@ -479,18 +505,28 @@ def test_get_artifact(tmp_path, test_artifact_name, expected_success):
                                         report_keys.absolute: {
                                             report_keys.maximum: -994,
                                             report_keys.minimum: -994
+                                        },
+                                        report_keys.relative: {
+                                            report_keys.maximum: -3.08,
+                                            report_keys.minimum: -3.08
                                         }
                                     },
-                                    report_keys.name: "flash"
+                                    report_keys.name: "flash",
+                                    report_keys.maximum: 32256,
                                 },
                                 {
                                     report_keys.delta: {
                                         report_keys.absolute: {
                                             report_keys.maximum: -175,
                                             report_keys.minimum: -175
+                                        },
+                                        report_keys.relative: {
+                                            report_keys.maximum: -8.54,
+                                            report_keys.minimum: -8.54
                                         }
                                     },
-                                    report_keys.name: "RAM for global variables"
+                                    report_keys.name: "RAM for global variables",
+                                    report_keys.maximum: 2048,
                                 }
                             ],
                             report_keys.sketches: [
@@ -500,26 +536,34 @@ def test_get_artifact(tmp_path, test_artifact_name, expected_success):
                                     report_keys.sizes: [
                                         {
                                             report_keys.current: {
-                                                report_keys.absolute: 1460
+                                                report_keys.absolute: 1460,
+                                                report_keys.relative: 4.53
                                             },
                                             report_keys.delta: {
-                                                report_keys.absolute: "N/A"
+                                                report_keys.absolute: "N/A",
+                                                report_keys.relative: "N/A"
                                             },
                                             report_keys.name: "flash",
-                                            "previous": {
-                                                report_keys.absolute: "N/A"
+                                            report_keys.maximum: 32256,
+                                            report_keys.previous: {
+                                                report_keys.absolute: "N/A",
+                                                report_keys.relative: "N/A"
                                             }
                                         },
                                         {
                                             report_keys.current: {
-                                                report_keys.absolute: 190
+                                                report_keys.absolute: 190,
+                                                report_keys.relative: 9.28
                                             },
                                             report_keys.delta: {
-                                                report_keys.absolute: "N/A"
+                                                report_keys.absolute: "N/A",
+                                                report_keys.relative: "N/A"
                                             },
                                             report_keys.name: "RAM for global variables",
-                                            "previous": {
-                                                report_keys.absolute: "N/A"
+                                            report_keys.maximum: 2048,
+                                            report_keys.previous: {
+                                                report_keys.absolute: "N/A",
+                                                report_keys.relative: "N/A"
                                             }
                                         }
                                     ]
@@ -530,26 +574,34 @@ def test_get_artifact(tmp_path, test_artifact_name, expected_success):
                                     report_keys.sizes: [
                                         {
                                             report_keys.current: {
-                                                report_keys.absolute: 444
+                                                report_keys.absolute: 444,
+                                                report_keys.relative: 1.38
                                             },
                                             report_keys.delta: {
-                                                report_keys.absolute: -994
+                                                report_keys.absolute: -994,
+                                                report_keys.relative: -3.08
                                             },
                                             report_keys.name: "flash",
-                                            "previous": {
-                                                report_keys.absolute: 1438
+                                            report_keys.maximum: 32256,
+                                            report_keys.previous: {
+                                                report_keys.absolute: 1438,
+                                                report_keys.relative: 4.46
                                             }
                                         },
                                         {
                                             report_keys.current: {
-                                                report_keys.absolute: 9
+                                                report_keys.absolute: 9,
+                                                report_keys.relative: 0.44
                                             },
                                             report_keys.delta: {
-                                                report_keys.absolute: -175
+                                                report_keys.absolute: -175,
+                                                report_keys.relative: -8.54
                                             },
                                             report_keys.name: "RAM for global variables",
-                                            "previous": {
-                                                report_keys.absolute: 184
+                                            report_keys.maximum: 2048,
+                                            report_keys.previous: {
+                                                report_keys.absolute: 184,
+                                                report_keys.relative: 8.98
                                             }
                                         }
                                     ]
@@ -581,25 +633,25 @@ def test_generate_report():
     sketches_report_path = test_data_path.joinpath("size-deltas-reports-new")
     expected_deltas_report = (
         "**Memory usage change @ d8fd302**\n\n"
-        "Board|flash|RAM for global variables\n"
-        "-|-|-\n"
-        "arduino:avr:leonardo|:green_heart: -12 - -12|0 - 0\n"
-        "arduino:avr:uno|:green_heart: -994 - -994|:green_heart: -175 - -175\n\n"
+        "Board|flash|%|RAM for global variables|%\n"
+        "-|-|-|-|-\n"
+        "arduino:avr:leonardo|:green_heart: -12 - -12|-0.05 - -0.05|0 - 0|0.0 - 0.0\n"
+        "arduino:avr:uno|:green_heart: -994 - -994|-3.08 - -3.08|:green_heart: -175 - -175|-8.54 - -8.54\n\n"
         "<details>\n"
         "<summary>Click for full report table</summary>\n\n"
-        "Board|examples/Bar<br>flash|examples/Bar<br>RAM for global variables|examples/Foo<br>flash|examples/Foo<br>"
-        "RAM for global variables\n"
-        "-|-|-|-|-\n"
-        "arduino:avr:leonardo|N/A|N/A|-12|0\n"
-        "arduino:avr:uno|N/A|N/A|-994|-175\n\n"
+        "Board|examples/Bar<br>flash|%|examples/Bar<br>RAM for global variables|%|examples/Foo<br>flash|%|examples/Foo"
+        "<br>RAM for global variables|%\n"
+        "-|-|-|-|-|-|-|-|-\n"
+        "arduino:avr:leonardo|N/A|N/A|N/A|N/A|-12|-0.05|0|0.0\n"
+        "arduino:avr:uno|N/A|N/A|N/A|N/A|-994|-3.08|-175|-8.54\n\n"
         "</details>\n\n"
         "<details>\n"
         "<summary>Click for full report CSV</summary>\n\n"
         "```\n"
-        "Board,examples/Bar<br>flash,examples/Bar<br>RAM for global variables,examples/Foo<br>flash,examples/Foo<br>"
-        "RAM for global variables\n"
-        "arduino:avr:leonardo,N/A,N/A,-12,0\n"
-        "arduino:avr:uno,N/A,N/A,-994,-175\n"
+        "Board,examples/Bar<br>flash,%,examples/Bar<br>RAM for global variables,%,examples/Foo<br>flash,%,examples/Foo"
+        "<br>RAM for global variables,%\n"
+        "arduino:avr:leonardo,N/A,N/A,N/A,N/A,-12,-0.05,0,0.0\n"
+        "arduino:avr:uno,N/A,N/A,N/A,N/A,-994,-3.08,-175,-8.54\n"
         "```\n"
         "</details>"
     )
@@ -799,15 +851,34 @@ def test_get_page_count():
     assert page_count == reportsizedeltas.get_page_count(link_header=link_header)
 
 
-@pytest.mark.parametrize("minimum, maximum, expected_value",
-                         [("N/A", "N/A", "N/A"),
-                          (-1, 0, ":green_heart: -1 - 0"),
-                          (0, 0, "0 - 0"),
-                          (0, 1, ":small_red_triangle: 0 - +1"),
-                          (1, 1, ":small_red_triangle: +1 - +1"),
-                          (-1, 1, ":grey_question: -1 - +1")])
-def test_get_summary_value(minimum, maximum, expected_value):
-    assert reportsizedeltas.get_summary_value(minimum=minimum, maximum=maximum) == expected_value
+@pytest.mark.parametrize("report, column_heading, expected_column_number, expected_report",
+                         [([["Board", "foo memory type", "%"], ["foo board", 12, 234]],
+                           "foo memory type",
+                           1,
+                           [["Board", "foo memory type", "%"], ["foo board", 12, 234]]),
+                          ([["Board", "foo memory type", "%"], ["foo board", 12, 234, "bar board"]],
+                           "bar memory type",
+                           3,
+                           [["Board", "foo memory type", "%", "bar memory type", "%"],
+                            ["foo board", 12, 234, "bar board", "", ""]])])
+def test_get_report_column_number(report, column_heading, expected_column_number, expected_report):
+    assert reportsizedeltas.get_report_column_number(
+        report=report,
+        column_heading=column_heading
+    ) == expected_column_number
+    assert report == expected_report
+
+
+@pytest.mark.parametrize("show_emoji, minimum, maximum, expected_value",
+                         [(True, "N/A", "N/A", "N/A"),
+                          (True, -1, 0, ":green_heart: -1 - 0"),
+                          (False, -1, 0, "-1 - 0"),
+                          (True, 0, 0, "0 - 0"),
+                          (True, 0, 1, ":small_red_triangle: 0 - +1"),
+                          (True, 1, 1, ":small_red_triangle: +1 - +1"),
+                          (True, -1, 1, ":grey_question: -1 - +1")])
+def test_get_summary_value(show_emoji, minimum, maximum, expected_value):
+    assert reportsizedeltas.get_summary_value(show_emoji=show_emoji, minimum=minimum, maximum=maximum) == expected_value
 
 
 def test_generate_markdown_table():


### PR DESCRIPTION
Previously, only absolute memory usage data was reported.

The memory usage as a percentage of the total available may often be even even more useful. For example, an increase of 10 bytes is much more significant on an ATtiny85 than it is on an ATSAMD21G18.

In order to calculate relative memory usage, it's necessary to know the total available memory. Total available memory is determined in the same manner as the absolute memory usage: by a regular expression on the compilation output. Some platforms are not configured to provide this information. In that case, the maximum and relative memory usage data will be recorded as "N/A" (see the MKR1000 job in the [demonstration PR](https://github.com/per1234/ArduinoIoTCloud/pull/6#issuecomment-684138195)).

---
PR demonstrating the relative memory usage reporting features added in this PR:
https://github.com/per1234/ArduinoIoTCloud/pull/6#issuecomment-684138195

**Memory usage change @ 69b76a635b6e9fb28764560d789c9da747b312e0**

Board|flash|%|RAM for global variables|%
-|-|-|-|-
arduino-beta:mbed:envie_m4|0 - 0|0.0 - 0.0|0 - 0|0.0 - 0.0
arduino-beta:mbed:envie_m7|0 - 0|0.0 - 0.0|0 - 0|0.0 - 0.0
arduino:samd:mkr1000|:grey_question: -144 - +32|-0.05 - +0.01|0 - 0|N/A
arduino:samd:mkrgsm1400|:green_heart: -136 - 0|-0.05 - 0.0|0 - 0|0.0 - 0.0
arduino:samd:mkrnb1500|0 - 0|0.0 - 0.0|0 - 0|0.0 - 0.0
arduino:samd:mkrwan1300|0 - 0|0.0 - 0.0|0 - 0|0.0 - 0.0
arduino:samd:mkrwifi1010|:small_red_triangle: 0 - +32|0.0 - +0.01|0 - 0|0.0 - 0.0
arduino:samd:nano_33_iot|0 - 0|0.0 - 0.0|0 - 0|0.0 - 0.0
esp8266:esp8266:huzzah|:small_red_triangle: +56 - +56|+0.01 - +0.01|:small_red_triangle: +64 - +64|+0.08 - +0.08

<details>
<summary>Click for full report table</summary>

Board|examples/ArduinoIoTCloud-Advanced<br>flash|%|examples/ArduinoIoTCloud-Advanced<br>RAM for global variables|%|examples/ArduinoIoTCloud-Basic<br>flash|%|examples/ArduinoIoTCloud-Basic<br>RAM for global variables|%|examples/utility/ArduinoIoTCloud_Travis_CI<br>flash|%|examples/utility/ArduinoIoTCloud_Travis_CI<br>RAM for global variables|%|examples/utility/Provisioning<br>flash|%|examples/utility/Provisioning<br>RAM for global variables|%|examples/utility/SelfProvisioning<br>flash|%|examples/utility/SelfProvisioning<br>RAM for global variables|%
-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-
arduino-beta:mbed:envie_m4|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0
arduino-beta:mbed:envie_m7|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0
arduino:samd:mkr1000|32|0.01|0|N/A|-144|-0.05|0|N/A|0|0.0|0|N/A|0|0.0|0|N/A
arduino:samd:mkrgsm1400|0|0.0|0|0.0|-136|-0.05|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0
arduino:samd:mkrnb1500|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0
arduino:samd:mkrwan1300|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0||||
arduino:samd:mkrwifi1010|32|0.01|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0
arduino:samd:nano_33_iot|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0|0|0.0
esp8266:esp8266:huzzah|56|0.01|64|0.08|56|0.01|64|0.08|56|0.01|64|0.08||||||||

</details>

<details>
<summary>Click for full report CSV</summary>

```
Board,examples/ArduinoIoTCloud-Advanced<br>flash,%,examples/ArduinoIoTCloud-Advanced<br>RAM for global variables,%,examples/ArduinoIoTCloud-Basic<br>flash,%,examples/ArduinoIoTCloud-Basic<br>RAM for global variables,%,examples/utility/ArduinoIoTCloud_Travis_CI<br>flash,%,examples/utility/ArduinoIoTCloud_Travis_CI<br>RAM for global variables,%,examples/utility/Provisioning<br>flash,%,examples/utility/Provisioning<br>RAM for global variables,%,examples/utility/SelfProvisioning<br>flash,%,examples/utility/SelfProvisioning<br>RAM for global variables,%
arduino-beta:mbed:envie_m4,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0
arduino-beta:mbed:envie_m7,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0
arduino:samd:mkr1000,32,0.01,0,N/A,-144,-0.05,0,N/A,0,0.0,0,N/A,0,0.0,0,N/A
arduino:samd:mkrgsm1400,0,0.0,0,0.0,-136,-0.05,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0
arduino:samd:mkrnb1500,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0
arduino:samd:mkrwan1300,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,,,,
arduino:samd:mkrwifi1010,32,0.01,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0
arduino:samd:nano_33_iot,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0,0,0.0
esp8266:esp8266:huzzah,56,0.01,64,0.08,56,0.01,64,0.08,56,0.01,64,0.08,,,,,,,,
```
</details>

---
Although this does add additional structure to the report format, it doesn't make any changes to the existing structure. The updates to `arduino/actions/libraries/report-size-deltas` do require the added structures, but it detects reports with the old format and skips them.  `arduino/actions/libraries/report-size-trends` works with the expanded report format without needing any changes. For these reasons, this is not a breaking change.