### PR TITLE
libraries/*: check code coverage during CI workflow run

### DIFF
--- a/.github/workflows/libraries_compile-examples.yml
+++ b/.github/workflows/libraries_compile-examples.yml
@@ -35,7 +35,14 @@ jobs:
           pip install --quiet pep8-naming
           flake8 --config "$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches/.flake8" --show-source "$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches"
 
-      - name: Run Python unit tests
+      - name: Run Python unit tests and report code coverage
         run: |
           export PYTHONPATH="$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches"
-          pytest "$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches/tests"
+          coverage run --source="$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches" --module pytest "$GITHUB_WORKSPACE/libraries/compile-examples/compilesketches/tests"
+          # Display code coverage report in workflow run log
+          coverage report
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/libraries_report-size-deltas.yml
+++ b/.github/workflows/libraries_report-size-deltas.yml
@@ -35,7 +35,14 @@ jobs:
           pip install --quiet pep8-naming
           flake8 --config "$GITHUB_WORKSPACE/libraries/report-size-deltas/.flake8" --show-source "$GITHUB_WORKSPACE/libraries/report-size-deltas"
 
-      - name: Run Python unit tests
+      - name: Run Python unit tests and report code coverage
         run: |
           export PYTHONPATH="$GITHUB_WORKSPACE/libraries/report-size-deltas"
-          pytest "$GITHUB_WORKSPACE/libraries/report-size-deltas/tests"
+          coverage run --source="$GITHUB_WORKSPACE/libraries/report-size-deltas" --module pytest "$GITHUB_WORKSPACE/libraries/report-size-deltas/tests"
+          # Display code coverage report in workflow run log
+          coverage report
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/libraries_report-size-trends.yml
+++ b/.github/workflows/libraries_report-size-trends.yml
@@ -35,7 +35,14 @@ jobs:
           pip install --quiet pep8-naming
           flake8 --config "$GITHUB_WORKSPACE/libraries/report-size-trends/reportsizetrends/.flake8" --show-source "$GITHUB_WORKSPACE/libraries/report-size-trends/reportsizetrends"
 
-      - name: Run Python unit tests
+      - name: Run Python unit tests and report code coverage
         run: |
           export PYTHONPATH="$GITHUB_WORKSPACE/libraries/report-size-trends/reportsizetrends"
-          pytest "$GITHUB_WORKSPACE/libraries/report-size-trends/reportsizetrends/tests"
+          coverage run --source="$GITHUB_WORKSPACE/libraries/report-size-trends/reportsizetrends" --module pytest "$GITHUB_WORKSPACE/libraries/report-size-trends/reportsizetrends/tests"
+          # Display code coverage report in workflow run log
+          coverage report
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/libraries/compile-examples/codecov.yml
+++ b/libraries/compile-examples/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  range: "100...100"
+  status:
+    project:
+      default:
+        threshold: 0%

--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -1385,4 +1385,4 @@ def get_head_commit_hash():
 
 # Only execute the following code if the script is run directly, not imported
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/libraries/compile-examples/compilesketches/tests/requirements.txt
+++ b/libraries/compile-examples/compilesketches/tests/requirements.txt
@@ -1,3 +1,4 @@
 --requirement ../requirements.txt
+coverage==5.2.1
 pytest==5.4.2
 pytest-mock==3.1.0

--- a/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
+++ b/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
@@ -104,7 +104,7 @@ def test_main(capsys,
 
     class CompileSketches:
         def compile_sketches(self):
-            pass
+            pass  # pragma: no cover
 
     monkeypatch.setenv("INPUT_CLI-VERSION", cli_version)
     monkeypatch.setenv("INPUT_FQBN", fqbn_arg)
@@ -238,10 +238,10 @@ def test_get_pull_request_base_ref(monkeypatch, mocker):
             self.base = self
 
         def get_repo(self):
-            pass
+            pass  # pragma: no cover
 
         def get_pull(self, number):
-            pass
+            pass  # pragma: no cover
 
     github_api_object = Github()
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(test_data_path.joinpath("githubevent.json")))
@@ -1228,7 +1228,7 @@ def test_get_sketch_report(mocker, do_size_deltas_report):
             self.git = self
 
         def checkout(self):
-            pass
+            pass  # pragma: no cover
 
     compile_sketches = get_compilesketches_object()
 
@@ -1519,10 +1519,10 @@ def test_checkout_deltas_base_ref(monkeypatch, mocker):
             self.git = self
 
         def fetch(self):
-            pass
+            pass  # pragma: no cover
 
         def checkout(self):
-            pass
+            pass  # pragma: no cover
 
     compile_sketches = get_compilesketches_object(enable_size_deltas_report="true", deltas_base_ref=deltas_base_ref)
 
@@ -2259,7 +2259,7 @@ def test_get_head_commit_hash(monkeypatch, mocker, github_event, expected_hash):
             self.git = self
 
         def rev_parse(self):
-            pass
+            pass  # pragma: no cover
 
     monkeypatch.setenv("GITHUB_EVENT_NAME", github_event)
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(test_data_path.joinpath("githubevent.json")))

--- a/libraries/report-size-deltas/codecov.yml
+++ b/libraries/report-size-deltas/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  range: "100...100"
+  status:
+    project:
+      default:
+        threshold: 0%

--- a/libraries/report-size-deltas/reportsizedeltas.py
+++ b/libraries/report-size-deltas/reportsizedeltas.py
@@ -690,4 +690,4 @@ def generate_csv_table(row_list):
 
 # Only execute the following code if the script is run directly, not imported
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/libraries/report-size-deltas/tests/requirements.txt
+++ b/libraries/report-size-deltas/tests/requirements.txt
@@ -1,2 +1,3 @@
+coverage==5.2.1
 pytest==5.4.2
 pytest-mock==3.1.0

--- a/libraries/report-size-deltas/tests/test_reportsizedeltas.py
+++ b/libraries/report-size-deltas/tests/test_reportsizedeltas.py
@@ -102,7 +102,7 @@ def test_main(monkeypatch, mocker):
 
         def report_size_deltas(self):
             """Stub"""
-            pass
+            pass    # pragma: no cover
 
     mocker.patch("reportsizedeltas.set_verbosity", autospec=True)
     mocker.patch("reportsizedeltas.ReportSizeDeltas", autospec=True, return_value=ReportSizeDeltas())
@@ -621,7 +621,7 @@ def test_get_sketches_reports(sketches_reports_path, expected_sketches_reports):
     try:
         distutils.dir_util.copy_tree(src=str(sketches_reports_path),
                                      dst=artifact_folder_object.name)
-    except Exception:
+    except Exception:   # pragma: no cover
         artifact_folder_object.cleanup()
         raise
     sketches_reports = report_size_deltas.get_sketches_reports(artifact_folder_object=artifact_folder_object)
@@ -662,7 +662,7 @@ def test_generate_report():
     try:
         distutils.dir_util.copy_tree(src=str(sketches_report_path),
                                      dst=artifact_folder_object.name)
-    except Exception:
+    except Exception:   # pragma: no cover
         artifact_folder_object.cleanup()
         raise
     sketches_reports = report_size_deltas.get_sketches_reports(artifact_folder_object=artifact_folder_object)

--- a/libraries/report-size-trends/codecov.yml
+++ b/libraries/report-size-trends/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  range: "100...100"
+  status:
+    project:
+      default:
+        threshold: 0%

--- a/libraries/report-size-trends/reportsizetrends/reportsizetrends.py
+++ b/libraries/report-size-trends/reportsizetrends/reportsizetrends.py
@@ -449,4 +449,4 @@ def get_spreadsheet_column_letters_from_number(column_number):
 
 # Only execute the following code if the script is run directly, not imported
 if __name__ == '__main__':
-    main()
+    main()  # pragma: no cover

--- a/libraries/report-size-trends/reportsizetrends/tests/requirements.txt
+++ b/libraries/report-size-trends/reportsizetrends/tests/requirements.txt
@@ -1,3 +1,4 @@
 --requirement ../requirements.txt
+coverage==5.2.1
 pytest==5.4.2
 pytest-mock==3.1.0

--- a/libraries/report-size-trends/reportsizetrends/tests/test_reportsizetrends.py
+++ b/libraries/report-size-trends/reportsizetrends/tests/test_reportsizetrends.py
@@ -25,17 +25,17 @@ class Service:
         return Service()
 
     def get(self):
-        pass
+        pass    # pragma: no cover
 
     def update(self):
-        pass
+        pass    # pragma: no cover
 
     # noinspection PyPep8Naming
     def batchUpdate(self):  # noqa: N802
-        pass
+        pass    # pragma: no cover
 
     def execute(self):
-        pass
+        pass    # pragma: no cover
 
 
 reportsizetrends.set_verbosity(enable_verbosity=False)
@@ -113,7 +113,7 @@ def test_main(monkeypatch, mocker):
 
     class ReportSizeTrends:
         def report_size_trends(self):
-            pass
+            pass    # pragma: no cover
 
     monkeypatch.setenv("INPUT_SKETCHES-REPORT-PATH", sketches_report_path)
     monkeypatch.setenv("INPUT_GOOGLE-KEY-FILE", google_key_file)


### PR DESCRIPTION
During the CI workflow run testing the code of the libraries actions:
- Generage code coverage report
- Display coverage report in workflow run log
- Upload coverage report to Codecov

Codecov will:
- Comment a coverage report to pull requests
- Cause the check status to be failure when a decrease in coverage was caused