### PR TITLE
libraries/compile-examples: install Library Manager sourced library dependencies last

### DIFF
--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -616,9 +616,6 @@ class CompileSketches:
             # that behavior is retained when using the old input syntax
             library_list.path = [{self.dependency_source_path_key: os.environ["GITHUB_WORKSPACE"]}]
 
-        if len(library_list.manager) > 0:
-            self.install_libraries_from_library_manager(library_list=library_list.manager)
-
         if len(library_list.path) > 0:
             self.install_libraries_from_path(library_list=library_list.path)
 
@@ -627,6 +624,13 @@ class CompileSketches:
 
         if len(library_list.download) > 0:
             self.install_libraries_from_download(library_list=library_list.download)
+
+        # Library dependencies of Library Manager sourced libraries (as defined in its metadata file) are automatically
+        # installed by Arduino CLI. Although convenient, this could conflict with the user specified installation of the
+        # dependency from a non-Library Manager source. Automatic installation of dependencies already installed is
+        # skipped, so Library Manager sourced libraries must be installed last.
+        if len(library_list.manager) > 0:
+            self.install_libraries_from_library_manager(library_list=library_list.manager)
 
     def install_libraries_from_library_manager(self, library_list):
         """Install libraries using the Arduino Library Manager


### PR DESCRIPTION
Library dependencies of Library Manager sourced libraries (as defined in its `library.properties` metadata file) are automatically installed by Arduino CLI. Previously, libraries from Library Manager sources were arbitrarily installed before the libraries from other sources. When the user of the action defined a library dependency that was also automatically installed via the Library Manager dependency system, the workflow step using the action would fail on the installation of the library from the user's definition due to the library already having been installed.

Arduino CLI skips automatic installation of any library dependency that is already installed, so simply doing the installations of libraries from Library Manager last solves the problem. The user has complete control over whick libraries are installed from the other sources, so there is no problem with conflicting installations between those sources.

In the case of the platform dependencies, the required order is the opposite because of the provision for installing the platform via Boards Manager for its toolchain, then overriding the platform with a version from another source. So there is no need to change the installation order for platform dependencies.

---
Because the Arduino_ConnectionHandler library is defined in the ArduinoIoTCloud library's metadata as a dependency, the following workflow step fails before this change:
```yaml
- uses: arduino/actions/libraries/compile-examples@master
  with:
    libraries: |
      # Install Arduino_ConnectionHandler library by cloning the Git repository
      - source-url: https://github.com/arduino-libraries/Arduino_ConnectionHandler.git
      # Install ArduinoIoTCloud library from Library Manager
      - name: ArduinoIoTCloud
```
with the error:
```
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git clone --depth=1 -v https://github.com/arduino-libraries/Arduino_ConnectionHandler.git /github/home/Arduino/libraries/Arduino_ConnectionHandler
  stderr: 'fatal: destination path '/github/home/Arduino/libraries/Arduino_ConnectionHandler' already exists and is not an empty directory.
```