### PR TITLE
libraries/compile-examples: fix conflict between explicit and automated library dependency installation

### DIFF
--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -706,9 +706,15 @@ class CompileSketches:
         Keyword arguments:
         library_list -- list of dictionaries defining the dependencies
         """
-        lib_install_command = ["lib", "install"]
-        lib_install_command.extend([self.get_manager_dependency_name(library) for library in library_list])
-        self.run_arduino_cli_command(command=lib_install_command, enable_output=self.get_run_command_output_level())
+        lib_install_base_command = ["lib", "install"]
+        # `arduino-cli lib install` fails if one of the libraries in the list has a dependency on another, but an
+        # earlier version of the dependency is specified in the list. The solution is to install one library at a time
+        # (even though `arduino-cli lib install` supports installing multiple libraries at once). This also allows the
+        # user to control which version is installed in the end by the order of the list passed via the libraries input.
+        for library in library_list:
+            lib_install_command = lib_install_base_command.copy()
+            lib_install_command.append(self.get_manager_dependency_name(library))
+            self.run_arduino_cli_command(command=lib_install_command, enable_output=self.get_run_command_output_level())
 
     def install_libraries_from_path(self, library_list):
         """Install libraries from local paths

--- a/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
+++ b/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
@@ -926,10 +926,22 @@ def test_install_libraries_from_library_manager(mocker):
 
     compile_sketches.install_libraries_from_library_manager(library_list=library_list)
 
-    lib_install_command = ["lib", "install"] + [library["name"] for library in library_list]
-    compile_sketches.run_arduino_cli_command.assert_called_once_with(compile_sketches,
-                                                                     command=lib_install_command,
-                                                                     enable_output=run_command_output_level)
+    lib_install_base_command = ["lib", "install"]
+
+    run_arduino_cli_command_calls = []
+    for library in library_list:
+        lib_install_command = lib_install_base_command.copy()
+        lib_install_command.append(library["name"])
+        run_arduino_cli_command_calls.append(
+            unittest.mock.call(
+                compile_sketches,
+                command=lib_install_command,
+                enable_output=run_command_output_level
+            )
+        )
+
+    # noinspection PyUnresolvedReferences
+    compile_sketches.run_arduino_cli_command.assert_has_calls(calls=run_arduino_cli_command_calls)
 
 
 @pytest.mark.parametrize(

--- a/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
+++ b/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
@@ -810,17 +810,17 @@ def test_install_platforms_from_download(mocker):
     compile_sketches.install_platforms_from_download(platform_list=platform_list)
 
     get_platform_installation_path_calls = []
-    install_platforms_from_download_calls = []
+    install_from_download_calls = []
     for platform, expected_source_path, in zip(platform_list, expected_source_path_list):
         get_platform_installation_path_calls.append(unittest.mock.call(compile_sketches, platform=platform))
-        install_platforms_from_download_calls.append(
+        install_from_download_calls.append(
             unittest.mock.call(url=platform[compilesketches.CompileSketches.dependency_source_url_key],
                                source_path=expected_source_path,
                                destination_parent_path=platform_installation_path.path.parent,
                                destination_name=platform_installation_path.path.name,
                                force=platform_installation_path.is_overwrite)
         )
-    compilesketches.install_from_download.assert_has_calls(calls=install_platforms_from_download_calls)
+    compilesketches.install_from_download.assert_has_calls(calls=install_from_download_calls)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Library dependencies of Library Manager sourced libraries (as defined in its [`library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format)) are automatically installed by Arduino CLI. This is a very nice feature, but unfortunately it was causing conflicts when the user explicitly defined a library dependency for libraries that were also automatically installed by the Arduino Library Manager dependency system.

---
There were several types of conflict:

When an explicit dependency definition for a Library Manager sourced library dependency with an earlier verison was also an automated Library Manager dependency:
```yaml
libraries: |
  # Install an earlier version of the Arduino_ConnectionHandler library
  - name: Arduino_ConnectionHandler
    version: 0.4.8
  # Install ArduinoIoTCloud library from Library Manager (it has an automated dependency on Arduino_ConnectionHandler)
  - name: ArduinoIoTCloud
```
Library Manager always installs the latest version of automated dependencies (Arduino_ConnectionHandler@0.4.9 is the current latest), so these explicit library dependency definitions resulted in a conflicting situation for Arduino CLI:
```
Running command: /github/home/bin/arduino-cli lib install Arduino_ConnectionHandler@0.4.8 ArduinoIoTCloud --log-level warn --verbose 
   Arduino_ConnectionHandler@0.4.8 depends on Arduino_ConnectionHandler@0.4.8
  Arduino_ConnectionHandler@0.4.8 depends on Arduino_DebugUtils@1.1.0
  Arduino_ConnectionHandler@0.4.8 depends on WiFi101@0.16.0
  Arduino_ConnectionHandler@0.4.8 depends on WiFiNINA@1.7.1
  Arduino_ConnectionHandler@0.4.8 depends on MKRGSM@1.5.0
  Arduino_ConnectionHandler@0.4.8 depends on MKRNB@1.3.2
  Arduino_ConnectionHandler@0.4.8 depends on MKRWAN@1.0.12
  ArduinoIoTCloud depends on ArduinoIoTCloud@0.11.1
  ArduinoIoTCloud depends on Arduino_ConnectionHandler@0.4.9
  The library Arduino_ConnectionHandler is required in two different versions: 0.4.9 and 0.4.8
```
Arduino CLI doesn't know what to do, so it just bails out with exit status 1 and no libraries installed.

This was solved by installing each Library Manager sourced explicit library dependency individually.

Previosly, the Arduino CLI command was:
```
arduino-cli lib install Arduino_ConnectionHandler@0.4.8 ArduinoIoTCloud
```
Now:
```
arduino-cli lib install Arduino_ConnectionHandler@0.4.8
arduino-cli lib install ArduinoIoTCloud
```
The automated dependency installation will still update explicit dependencies for an earlier version, but the user can control this with the order the dependencies are defined in the workflow:
```yaml
libraries: |
  - name: ArduinoIoTCloud
  - name: Arduino_ConnectionHandler
    version: 0.4.8
```
results in this order of commands:
```
arduino-cli lib install ArduinoIoTCloud
arduino-cli lib install Arduino_ConnectionHandler@0.4.8
```
So the explicit dependency definition downgrades the latest version installed as an automated dependency

---
When an explicit dependency definition for a repository sourced library dependency was also an automated Library Manager dependency:
```yaml
libraries: |
  # Install Arduino_ConnectionHandler library by cloning the Git repository
  - source-url: https://github.com/arduino-libraries/Arduino_ConnectionHandler.git
  - name: ArduinoIoTCloud
```
The Arduino_ConnectionHandler library was installed by Library Manager as an automated dependency, so the subsequent `git clone` to that path for the explicit Arduino_ConnectionHandler dependency fails:
```
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v https://github.com/arduino-libraries/Arduino_ConnectionHandler.git /github/home/Arduino/libraries/Arduino_ConnectionHandler
  stderr: 'fatal: destination path '/github/home/Arduino/libraries/Arduino_ConnectionHandler' already exists and is not an empty directory.
```
The solution is to configure the installation code to overwrite existing library installations.

---
When an explicit dependency definition for a local path sourced library dependency was also an automated Library Manager dependency:
```yaml
libraries: |
  # Install Arduino_ConnectionHandler library from the local path
  - source-path: Arduino_ConnectionHandler
  - name: ArduinoIoTCloud
```
The problem is the same as for the repository sourced explicit dependency:
```
FileExistsError: [Errno 17] File exists: '/github/workspace/Arduino_ConnectionHandler' -> '/github/home/Arduino/libraries/Arduino_ConnectionHandler'
```
The solution is to configure the installation code to overwrite existing library installations.

---
When an explicit dependency definition for a download sourced library dependency was also an automated Library Manager dependency:
```yaml
# Install Arduino_ConnectionHandler v0.4.8 from downloaded archive
- source-url: https://github.com/arduino-libraries/Arduino_ConnectionHandler/archive/0.4.8.zip
  destination-name: Arduino_ConnectionHandler
- name: ArduinoIoTCloud
```
Installation of the download sourced library dependency failed silently (LM installs 0.4.9):
```
ResolveLibrary(Arduino_ConnectionHandler.h)
  -> candidates: [Arduino_ConnectionHandler@0.4.9]
```
The solution is to configure the installation code to overwrite existing library installations.

---
My first instinct for how to fix the last three was to simply change the order the library dependency sources are installed so the Library Manager sourced libraries are installed last. However, there is another factor: If a library with a version lower than the latest version available from Library Manager is already installed, Arduino CLI updates it with the version from Library Manager. The exact version of the library dependencies specified by the user of the script must be retained, so this means the reordering solution won't work.