### PR TITLE
libraries/compile-examples: add support for submodules

### DIFF
--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -557,7 +557,8 @@ class CompileSketches:
         """
         if git_ref is None:
             # Shallow clone is only possible if using the tip of the branch
-            clone_arguments = {"depth": 1}
+            # Use `None` as value for `git clone` options with no argument
+            clone_arguments = {"depth": 1, "shallow-submodules": None, "recurse-submodules": True}
         else:
             clone_arguments = {}
         cloned_repository = git.Repo.clone_from(url=url, to_path=destination_path, **clone_arguments)
@@ -573,6 +574,7 @@ class CompileSketches:
 
             # checkout ref
             cloned_repository.git.checkout(git_ref)
+            cloned_repository.git.submodule("update", "--init", "--recursive", "--recommend-shallow")
 
     def install_platforms_from_download(self, platform_list):
         """Install libraries by downloading them

--- a/libraries/compile-examples/compilesketches/compilesketches.py
+++ b/libraries/compile-examples/compilesketches/compilesketches.py
@@ -813,7 +813,7 @@ class CompileSketches:
             previous_compilation_result = self.compile_sketch(sketch_path=compilation_result.sketch)
 
             # git checkout the head ref to return the repository to its previous state
-            repository.git.checkout(original_git_ref)
+            repository.git.checkout(original_git_ref, recurse_submodules=True)
 
             previous_sizes = self.get_sizes_from_output(compilation_result=previous_compilation_result)
 
@@ -940,11 +940,15 @@ class CompileSketches:
 
         # git fetch the deltas base ref
         origin_remote = repository.remotes["origin"]
-        origin_remote.fetch(refspec=self.deltas_base_ref, verbose=self.verbose, no_tags=True, prune=True,
-                            depth=1)
+        origin_remote.fetch(refspec=self.deltas_base_ref,
+                            verbose=self.verbose,
+                            no_tags=True,
+                            prune=True,
+                            depth=1,
+                            recurse_submodules=True)
 
         # git checkout the deltas base ref
-        repository.git.checkout(self.deltas_base_ref)
+        repository.git.checkout(self.deltas_base_ref, recurse_submodules=True)
 
     def get_sizes_report(self, current_sizes, previous_sizes):
         """Return a list containing all memory usage data assembled.

--- a/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
+++ b/libraries/compile-examples/compilesketches/tests/test_compilesketches.py
@@ -1267,7 +1267,7 @@ def test_get_sketch_report(mocker, do_size_deltas_report):
         git.Repo.assert_called_once_with(path=os.environ["GITHUB_WORKSPACE"])
         compile_sketches.checkout_deltas_base_ref.assert_called_once()
         compile_sketches.compile_sketch.assert_called_once_with(compile_sketches, sketch_path=compilation_result.sketch)
-        Repo.checkout.assert_called_once_with(original_git_ref)
+        Repo.checkout.assert_called_once_with(original_git_ref, recurse_submodules=True)
         get_sizes_from_output_calls.append(
             unittest.mock.call(compile_sketches, compilation_result=previous_compilation_result))
         expected_previous_sizes = sizes_list[1]
@@ -1549,9 +1549,11 @@ def test_checkout_deltas_base_ref(monkeypatch, mocker):
     git.Repo.assert_called_once_with(path=os.environ["GITHUB_WORKSPACE"])
     Repo.fetch.assert_called_once_with(refspec=deltas_base_ref,
                                        verbose=compile_sketches.verbose,
-                                       no_tags=True, prune=True,
-                                       depth=1)
-    Repo.checkout.assert_called_once_with(deltas_base_ref)
+                                       no_tags=True,
+                                       prune=True,
+                                       depth=1,
+                                       recurse_submodules=True)
+    Repo.checkout.assert_called_once_with(deltas_base_ref, recurse_submodules=True)
 
 
 def test_get_sizes_report(mocker):


### PR DESCRIPTION
This PR adds support for submodules in two ways:
- In dependencies installed from repository sources
- In the checkouts done to the repository under test when deltas reporting is enabled