### PR TITLE
GitHub api rate limiting improvements

### DIFF
--- a/setup-taskfile/__tests__/main.test.ts
+++ b/setup-taskfile/__tests__/main.test.ts
@@ -90,5 +90,17 @@ describe("installer tests", () => {
         expect(fs.existsSync(path.join(taskdir, "bin", "task"))).toBe(true);
       }
     });
+
+    it("Skips version computing when a valid semver is provided", async () => {
+      await installer.getTask("3.0.0", "");
+      const taskdir = path.join(toolDir, "task", "3.0.0", os.arch());
+
+      expect(fs.existsSync(`${taskdir}.complete`)).toBe(true);
+      if (IS_WINDOWS) {
+        expect(fs.existsSync(path.join(taskdir, "bin", "task.exe"))).toBe(true);
+      } else {
+        expect(fs.existsSync(path.join(taskdir, "bin", "task"))).toBe(true);
+      }
+    });
   });
 });

--- a/setup-taskfile/lib/installer.js
+++ b/setup-taskfile/lib/installer.js
@@ -122,6 +122,11 @@ function fetchVersions(repoToken) {
 // Compute an actual version starting from the `version` configuration param.
 function computeVersion(version, repoToken) {
     return __awaiter(this, void 0, void 0, function* () {
+        // return if passed version is a valid semver
+        if (semver.valid(version)) {
+            core.debug("valid semver provided, skipping computing actual version");
+            return `v${version}`; // Task releases are v-prefixed
+        }
         // strip leading `v` char (will be re-added later)
         if (version.startsWith("v")) {
             version = version.slice(1, version.length);

--- a/setup-taskfile/src/installer.ts
+++ b/setup-taskfile/src/installer.ts
@@ -123,6 +123,12 @@ async function computeVersion(
   version: string,
   repoToken: string
 ): Promise<string> {
+  // return if passed version is a valid semver
+  if (semver.valid(version)) {
+    core.debug("valid semver provided, skipping computing actual version");
+    return `v${version}`; // Task releases are v-prefixed
+  }
+
   // strip leading `v` char (will be re-added later)
   if (version.startsWith("v")) {
     version = version.slice(1, version.length);


### PR DESCRIPTION
As discussed in #65 we could improve in `setup-taskfile` GitHub API usage by removing querying the APIs each time the action is used.

This PR allow skipping querying the GitHub APIs if a valid `semver` is specified in the `version` action input parameter.