### PR TITLE
Add pySerial to the compile-examples container

### DIFF
--- a/libraries/compile-examples/compilesketches/requirements.txt
+++ b/libraries/compile-examples/compilesketches/requirements.txt
@@ -1,3 +1,4 @@
 GitPython==3.1.2
 PyGithub==1.51
 PyYAML==5.3.1
+PySerial==3.4


### PR DESCRIPTION
`pySerial` is needed to compile sketches for ESP32-based boards.
Without including it as a _compile-examples_ container dependency,
it is not possible to compile Arduino sketches for a wide range of modern
boards.