### PR TITLE
Fix unexpected input warning

### DIFF
--- a/setup-taskfile/action.yml
+++ b/setup-taskfile/action.yml
@@ -5,6 +5,9 @@ inputs:
   version:
     description: 'Version to use. Example: 2.6.0'
     default: '2.x'
+  repo-token:
+    description: "Token with permissions to do repo things"
+
 runs:
   using: 'node12'
   main: 'lib/main.js'


### PR DESCRIPTION
This PR tries to fix the warning:
```
Warning: Unexpected input(s) 'repo-token', valid inputs are ['version']
```
The problem comes from `repo-token` not being defined in the `action.yml`
[This comment](https://github.community/t/issue-not-created-and-action-shows-unexpected-input-repo-token-valid-inputs-are-joke-issue-title-warning/116568/3) helped me solve the issue