### PR TITLE
Task: Install v3.x.x by default

### DIFF
--- a/setup-taskfile/action.yml
+++ b/setup-taskfile/action.yml
@@ -3,8 +3,8 @@ description: 'Download Task and add it to the PATH'
 author: 'Arduino'
 inputs:
   version:
-    description: 'Version to use. Example: 2.6.0'
-    default: '2.x'
+    description: 'Version to use. Example: 3.4.2'
+    default: '3.x'
   repo-token:
     description: "Token with permissions to do repo things"
 


### PR DESCRIPTION
Hey there, Task author here.

I noticed that this action seems to be installing an old release by default. Checking the code, it was clear why.

Please note that I haven't really tested this change. If someone with more knowledge of GitHub Actions thinks this can break stuff for someone, please let me know.