### PR TITLE
Deprecate unmaintained setup-taskfile action copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ action in a Google Sheets spreadsheet.
 * [libraries/spell-check](./libraries/spell-check) checks the files of your
 repository for commonly misspelled words.
 
-* [setup-taskfile](./setup-taskfile) makes [Taskfile](https://taskfile.dev/#/)
-available to your Workflows.
+* [arduino/setup-task](https://github.com/arduino/setup-task) makes [Task](https://taskfile.dev/#/)
+available to your workflows.
+  * **WARNING**: The `arduino/actions/setup-taskfile` action
+  contained in this repository is deprecated. Please use the actively maintained
+  `arduino/setup-task` action at the link above.
 
 ---
 **Note**: Several actions previously hosted in this experimental repository have

--- a/setup-taskfile/README.md
+++ b/setup-taskfile/README.md
@@ -2,6 +2,16 @@
 
 This action makes the `task` binary available to Workflows.
 
+## DEPRECATION NOTICE
+
+**WARNING: the action has been moved to https://github.com/arduino/setup-task**
+
+This unmaintained copy is kept only to provide provisional support for existing workflows, but will be removed soon.
+
+See the migration guide:
+
+https://github.com/arduino/setup-task/releases/tag/v1.0.0
+
 ## Usage
 
 To get the latest stable version of Task just add this step:

--- a/setup-taskfile/lib/main.js
+++ b/setup-taskfile/lib/main.js
@@ -17,6 +17,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const installer = __importStar(require("./installer"));
+core.warning("This version of the action is deprecated. Use arduino/setup-task. See https://github.com/arduino/setup-task");
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {

--- a/setup-taskfile/src/main.ts
+++ b/setup-taskfile/src/main.ts
@@ -1,6 +1,10 @@
 import * as core from "@actions/core";
 import * as installer from "./installer";
 
+core.warning(
+  "This version of the action is deprecated. Use arduino/setup-task. See https://github.com/arduino/setup-task"
+);
+
 async function run() {
   try {
     let version = core.getInput("version");


### PR DESCRIPTION
The `setup-taskfile` action has been moved to a dedicated repository, where it is actively maintained:
https://github.com/arduino/setup-task

This fact is now communicated to visitors and users by:

- Notes in top level readme
- Notes in action level readmes
- Warning printed in workflow run summary and logs